### PR TITLE
Added inflate method in BaseScreenView that does not take context as …

### DIFF
--- a/magellan-library/src/main/java/com/wealthfront/magellan/BaseScreenView.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/BaseScreenView.java
@@ -27,6 +27,6 @@ public class BaseScreenView<S extends Screen> extends FrameLayout implements Scr
   }
 
   public View inflate(int resource, ViewGroup root) {
-    inflate(getContext(), resource, root);
+    return inflate(getContext(), resource, root);
   }
 }

--- a/magellan-library/src/main/java/com/wealthfront/magellan/BaseScreenView.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/BaseScreenView.java
@@ -1,5 +1,6 @@
 package com.wealthfront.magellan;
 
+import android.view.View;
 import android.content.Context;
 import android.widget.FrameLayout;
 

--- a/magellan-library/src/main/java/com/wealthfront/magellan/BaseScreenView.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/BaseScreenView.java
@@ -1,6 +1,7 @@
 package com.wealthfront.magellan;
 
 import android.view.View;
+import android.view.ViewGroup;
 import android.content.Context;
 import android.widget.FrameLayout;
 

--- a/magellan-library/src/main/java/com/wealthfront/magellan/BaseScreenView.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/BaseScreenView.java
@@ -24,4 +24,7 @@ public class BaseScreenView<S extends Screen> extends FrameLayout implements Scr
     return screen;
   }
 
+  public View inflate(int resource, ViewGroup root) {
+    inflate(getContext(), resource, root);
+  }
 }

--- a/magellan-library/src/main/java/com/wealthfront/magellan/BaseScreenView.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/BaseScreenView.java
@@ -1,7 +1,6 @@
 package com.wealthfront.magellan;
 
 import android.view.View;
-import android.view.ViewGroup;
 import android.content.Context;
 import android.widget.FrameLayout;
 
@@ -26,7 +25,7 @@ public class BaseScreenView<S extends Screen> extends FrameLayout implements Scr
     return screen;
   }
 
-  public View inflate(int resource, ViewGroup root) {
-    return inflate(getContext(), resource, root);
+  public View inflate(int resource) {
+    return inflate(getContext(), resource, this);
   }
 }


### PR DESCRIPTION
…parameter

I have mental issues and my OCD sometimes takes the best of me. In this case, this wrapper inflate method will simply use the getContext(), so that the view code will be even simpler and clean :)