### PR TITLE
Fix crash in Screen.showDialog()

### DIFF
--- a/magellan-library/src/main/java/com/wealthfront/magellan/Screen.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/Screen.java
@@ -114,7 +114,7 @@ public abstract class Screen<V extends ViewGroup & ScreenView> implements BackHa
   }
 
   final void createDialog() {
-    if (dialogCreator != null && dialogIsShowing) {
+    if (dialogCreator != null && dialogIsShowing && activity != null) {
       dialog = dialogCreator.createDialog(activity);
       dialog.show();
     }

--- a/magellan-library/src/test/java/com/wealthfront/magellan/ScreenTest.java
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/ScreenTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
+import static org.robolectric.Robolectric.setupActivity;
 
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner.class)
@@ -60,6 +61,7 @@ public class ScreenTest {
 
   @Test
   public void createDialog() {
+    screen.setActivity(setupActivity(Activity.class));
     screen.showDialog(new DialogCreator() {
       @Override
       public Dialog createDialog(Activity activity) {
@@ -69,10 +71,16 @@ public class ScreenTest {
     screen.createDialog();
 
     verify(dialog, times(2)).show();
+
+    // No-op interaction between onShow() and onHide()
+    screen.setActivity(null);
+    screen.createDialog();
+    verify(dialog, times(2)).show();
   }
 
   @Test
   public void destroyDialog() {
+    screen.setActivity(setupActivity(Activity.class));
     screen.showDialog(new DialogCreator() {
       @Override
       public Dialog createDialog(Activity activity) {


### PR DESCRIPTION
I have put my app under stress with the android monkey runner

$ `for i in $(seq 1 30 ) ; do adb shell monkey -p my.package -v 5000 ; done`

I got different crashes like this one that should be handled by Magellan itself

```kotlin
    fun showSomeDialog() {
        showDialog { activity ->
            AlertDialog.Builder(activity, R.style.AppTheme_NfcDialog)
                    .setTitle("Title")
                     ....
                    .show()
        }
    }
```


```
Fatal Exception: java.lang.NullPointerException:
Attempt to invoke virtual method 'java.lang.Object android.content.Context.getSystemService(java.lang.String)' on a null object reference
       at android.view.LayoutInflater.from(LayoutInflater.java:232)
       at android.view.ContextThemeWrapper.getSystemService(ContextThemeWrapper.java:167)
       at com.android.internal.app.AlertController$AlertParams.<init>(AlertController.java:992)
       at android.app.AlertDialog$Builder.<init>(AlertDialog.java:482)
       at com.mautinoa.client.p2p.DebugScreen$showSomeDialog$1.createDialog(DebugScreen.kt:144)
       at com.mautinoa.client.p2p.DebugScreen$showSomeDialog$1.createDialog(DebugScreen.kt:79)
       at com.wealthfront.magellan.Screen.createDialog(Screen.java:118)
       at com.wealthfront.magellan.Screen.showDialog(Screen.java:214)
```