### PR TITLE
Add optional listeners for transitions

### DIFF
--- a/magellan-library/src/main/java/com/wealthfront/magellan/Navigator.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/Navigator.java
@@ -528,19 +528,18 @@ public class Navigator implements BackHandler {
     backStackOperation.run();
     View to = showCurrentScreen(direction);
     currentScreen().onResume(activity);
-    animateAndRemove(from, to, navType, direction, currentScreen());
+    animateAndRemove(from, to, navType, direction);
     reportEvent(navType, direction);
   }
 
-  private void animateAndRemove(final View from, final View to, final NavigationType navType, final Direction direction,
-                                final Screen currentScreen) {
+  private void animateAndRemove(final View from, final View to, final NavigationType navType, final Direction direction) {
     ghostView = from;
     final Transition transitionToUse = overridingTransition != null ? overridingTransition : transition;
     overridingTransition = null;
     whenMeasured(to, new Views.OnMeasured() {
       @Override
       public void onMeasured() {
-        currentScreen.transitionStarted();
+        currentScreen().transitionStarted();
         transitionToUse.animate(from, to, navType, direction, new Transition.Callback() {
           @Override
           public void onAnimationEnd() {
@@ -550,7 +549,7 @@ public class Navigator implements BackHandler {
                 // Only clear the ghost if it's the same as the view we just removed
                 ghostView = null;
               }
-              currentScreen.transitionFinished();
+              currentScreen().transitionFinished();
               container.setInterceptTouchEvents(false);
             }
           }

--- a/magellan-library/src/main/java/com/wealthfront/magellan/Navigator.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/Navigator.java
@@ -528,12 +528,13 @@ public class Navigator implements BackHandler {
     backStackOperation.run();
     View to = showCurrentScreen(direction);
     currentScreen().onResume(activity);
-    animateAndRemove(from, to, navType, direction);
+    animateAndRemove(from, to, navType, direction, currentScreen());
     reportEvent(navType, direction);
   }
 
-  private void animateAndRemove(
-      final View from, final View to, final NavigationType navType, final Direction direction) {
+  private void animateAndRemove(final View from, final View to, final NavigationType navType, final Direction direction,
+                                final Screen currentScreen) {
+    currentScreen.onTransitionStarted();
     ghostView = from;
     final Transition transitionToUse = overridingTransition != null ? overridingTransition : transition;
     overridingTransition = null;
@@ -549,6 +550,7 @@ public class Navigator implements BackHandler {
                 // Only clear the ghost if it's the same as the view we just removed
                 ghostView = null;
               }
+              currentScreen.onTransitionFinished();
               container.setInterceptTouchEvents(false);
             }
           }

--- a/magellan-library/src/main/java/com/wealthfront/magellan/Navigator.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/Navigator.java
@@ -534,13 +534,13 @@ public class Navigator implements BackHandler {
 
   private void animateAndRemove(final View from, final View to, final NavigationType navType, final Direction direction,
                                 final Screen currentScreen) {
-    currentScreen.onTransitionStarted();
     ghostView = from;
     final Transition transitionToUse = overridingTransition != null ? overridingTransition : transition;
     overridingTransition = null;
     whenMeasured(to, new Views.OnMeasured() {
       @Override
       public void onMeasured() {
+        currentScreen.transitionStarted();
         transitionToUse.animate(from, to, navType, direction, new Transition.Callback() {
           @Override
           public void onAnimationEnd() {
@@ -550,7 +550,7 @@ public class Navigator implements BackHandler {
                 // Only clear the ghost if it's the same as the view we just removed
                 ghostView = null;
               }
-              currentScreen.onTransitionFinished();
+              currentScreen.transitionFinished();
               container.setInterceptTouchEvents(false);
             }
           }

--- a/magellan-library/src/main/java/com/wealthfront/magellan/Screen.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/Screen.java
@@ -49,7 +49,7 @@ public abstract class Screen<V extends ViewGroup & ScreenView> implements BackHa
   private boolean dialogIsShowing;
   private Dialog dialog;
   private SparseArray<Parcelable> viewState;
-  private boolean transitionFinished = false;
+  private boolean transitionFinished = true;
   private Queue<TransitionFinishedListener> transitionFinishedListeners = new LinkedList<>();
 
   /**

--- a/magellan-library/src/main/java/com/wealthfront/magellan/Screen.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/Screen.java
@@ -50,7 +50,7 @@ public abstract class Screen<V extends ViewGroup & ScreenView> implements BackHa
   private Dialog dialog;
   private SparseArray<Parcelable> viewState;
   private boolean isTransitioning;
-  private Queue<TransitionFinishedListener> transitionFinishedListeners;
+  private Queue<TransitionFinishedListener> transitionFinishedListeners = new LinkedList<>();
 
   /**
    * @return the View associated with this Screen or null if we are not in between {@link #onShow(Context)} and\
@@ -134,16 +134,14 @@ public abstract class Screen<V extends ViewGroup & ScreenView> implements BackHa
     }
   }
 
-  final void transitionStarted() {
+  void transitionStarted() {
     isTransitioning = true;
-    if (transitionFinishedListeners != null) {
-      transitionFinishedListeners.clear();
-    }
+    transitionFinishedListeners.clear();
   }
 
-  final void transitionFinished() {
+  void transitionFinished() {
     isTransitioning = false;
-    while (transitionFinishedListeners != null && transitionFinishedListeners.size() > 0) {
+    while (transitionFinishedListeners.size() > 0) {
       transitionFinishedListeners.remove().onTransitionFinished();
     }
   }
@@ -155,9 +153,6 @@ public abstract class Screen<V extends ViewGroup & ScreenView> implements BackHa
    */
   protected final void whenTransitionFinished(TransitionFinishedListener listener) {
     if (isTransitioning) {
-      if (transitionFinishedListeners == null) {
-        transitionFinishedListeners = new LinkedList<>();
-      }
       transitionFinishedListeners.add(listener);
     } else {
       listener.onTransitionFinished();

--- a/magellan-library/src/main/java/com/wealthfront/magellan/Screen.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/Screen.java
@@ -153,7 +153,7 @@ public abstract class Screen<V extends ViewGroup & ScreenView> implements BackHa
    * or immediately if the screen is not currently transitioning.
    * @param listener The listener to be called when the transition is finished or immediately.
    */
-  protected void whenTransitionFinished(TransitionFinishedListener listener) {
+  final void whenTransitionFinished(TransitionFinishedListener listener) {
     if (isTransitioning) {
       if (transitionFinishedListeners == null) {
         transitionFinishedListeners = new LinkedList<>();

--- a/magellan-library/src/main/java/com/wealthfront/magellan/Screen.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/Screen.java
@@ -134,17 +134,35 @@ public abstract class Screen<V extends ViewGroup & ScreenView> implements BackHa
     }
   }
 
-  protected void onTransitionStarted() {
+  final void transitionStarted() {
     transitionFinished = false;
+    onTransitionStarted();
   }
 
-  protected void onTransitionFinished() {
+  /**
+   * Override this to run code when the screen starts its navigation transition in or out. The screen is partially
+   * visible and animating, and its views are measured.
+   */
+  protected void onTransitionStarted() {}
+
+  final void transitionFinished() {
     transitionFinished = true;
     while (transitionFinishedListeners.size() > 0) {
       transitionFinishedListeners.remove().onTransitionFinished();
     }
+    onTransitionFinished();
   }
 
+  /**
+   * Override this to run code when the screen finishes its navigation transition in. The screen is now fully visible.
+   */
+  protected void onTransitionFinished() {}
+
+  /**
+   * Adds a {@link TransitionFinishedListener} to be called when the navigation transition into the screen is finished,
+   * or immediately if the screen is not currently transitioning.
+   * @param listener The listener to be called when the transition is finished or immediately.
+   */
   protected void whenTransitionFinished(TransitionFinishedListener listener) {
     if (transitionFinished) {
       listener.onTransitionFinished();
@@ -280,8 +298,14 @@ public abstract class Screen<V extends ViewGroup & ScreenView> implements BackHa
     checkState(activity == null, reason);
   }
 
+  /**
+   * A simple interface with a method to be run when the screen's transition is finished.
+   */
   public interface TransitionFinishedListener {
 
+    /**
+     * The method to run when the screen's transition is finished.
+     */
     void onTransitionFinished();
 
   }

--- a/magellan-library/src/main/java/com/wealthfront/magellan/Screen.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/Screen.java
@@ -134,11 +134,11 @@ public abstract class Screen<V extends ViewGroup & ScreenView> implements BackHa
     }
   }
 
-  void onTransitionStarted() {
+  protected void onTransitionStarted() {
     transitionFinished = false;
   }
 
-  void onTransitionFinished() {
+  protected void onTransitionFinished() {
     transitionFinished = true;
     while (transitionFinishedListeners.size() > 0) {
       transitionFinishedListeners.remove().onTransitionFinished();

--- a/magellan-library/src/main/java/com/wealthfront/magellan/Screen.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/Screen.java
@@ -153,7 +153,7 @@ public abstract class Screen<V extends ViewGroup & ScreenView> implements BackHa
    * or immediately if the screen is not currently transitioning.
    * @param listener The listener to be called when the transition is finished or immediately.
    */
-  final void whenTransitionFinished(TransitionFinishedListener listener) {
+  protected final void whenTransitionFinished(TransitionFinishedListener listener) {
     if (isTransitioning) {
       if (transitionFinishedListeners == null) {
         transitionFinishedListeners = new LinkedList<>();

--- a/magellan-library/src/test/java/com/wealthfront/magellan/ScreenTest.java
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/ScreenTest.java
@@ -114,17 +114,17 @@ public class ScreenTest {
   @Test
   public void whenTransitionFinished() {
     final Screen.TransitionFinishedListener listener = mock(Screen.TransitionFinishedListener.class);
-    screen.onTransitionStarted();
+    screen.transitionStarted();
 
     screen.whenTransitionFinished(listener);
     verify(listener, never()).onTransitionFinished();
 
-    screen.onTransitionFinished();
+    screen.transitionFinished();
     verify(listener).onTransitionFinished();
 
     reset(listener);
-    screen.onTransitionStarted();
-    screen.onTransitionFinished();
+    screen.transitionStarted();
+    screen.transitionFinished();
     verify(listener, never()).onTransitionFinished();
   }
 
@@ -135,16 +135,16 @@ public class ScreenTest {
     verify(listener).onTransitionFinished();
 
     reset(listener);
-    screen.onTransitionStarted();
-    screen.onTransitionFinished();
+    screen.transitionStarted();
+    screen.transitionFinished();
     verify(listener, never()).onTransitionFinished();
   }
 
   @Test
   public void whenTransitionFinished_afterTransitionFinished() {
     final Screen.TransitionFinishedListener listener = mock(Screen.TransitionFinishedListener.class);
-    screen.onTransitionStarted();
-    screen.onTransitionFinished();
+    screen.transitionStarted();
+    screen.transitionFinished();
 
     screen.whenTransitionFinished(listener);
     verify(listener).onTransitionFinished();

--- a/magellan-library/src/test/java/com/wealthfront/magellan/ScreenTest.java
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/ScreenTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -120,6 +121,23 @@ public class ScreenTest {
 
     screen.onTransitionFinished();
     verify(listener).onTransitionFinished();
+
+    reset(listener);
+    screen.onTransitionStarted();
+    screen.onTransitionFinished();
+    verify(listener, never()).onTransitionFinished();
+  }
+
+  @Test
+  public void whenTransitionFinished_beforeTransitionStarted() {
+    final Screen.TransitionFinishedListener listener = mock(Screen.TransitionFinishedListener.class);
+    screen.whenTransitionFinished(listener);
+    verify(listener).onTransitionFinished();
+
+    reset(listener);
+    screen.onTransitionStarted();
+    screen.onTransitionFinished();
+    verify(listener, never()).onTransitionFinished();
   }
 
   @Test

--- a/magellan-library/src/test/java/com/wealthfront/magellan/ScreenTest.java
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/ScreenTest.java
@@ -22,6 +22,8 @@ import org.robolectric.annotation.Config;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -106,6 +108,28 @@ public class ScreenTest {
     verify(view).saveHierarchyState(isA(SparseArray.class));
     verify(view).restoreHierarchyState(sparseArrayCaptor.capture());
     assertThat(((Bundle) sparseArrayCaptor.getValue().get(42)).getString("key")).isEqualTo("value");
+  }
+
+  @Test
+  public void whenTransitionFinished() {
+    final Screen.TransitionFinishedListener listener = mock(Screen.TransitionFinishedListener.class);
+    screen.onTransitionStarted();
+
+    screen.whenTransitionFinished(listener);
+    verify(listener, never()).onTransitionFinished();
+
+    screen.onTransitionFinished();
+    verify(listener).onTransitionFinished();
+  }
+
+  @Test
+  public void whenTransitionFinished_afterTransitionFinished() {
+    final Screen.TransitionFinishedListener listener = mock(Screen.TransitionFinishedListener.class);
+    screen.onTransitionStarted();
+    screen.onTransitionFinished();
+
+    screen.whenTransitionFinished(listener);
+    verify(listener).onTransitionFinished();
   }
 
   private static class DummyScreen extends Screen<BaseScreenView<DummyScreen>> {


### PR DESCRIPTION
Add a way for a screen to listen for transitions to finish. This allows one to delay view updating and avoid animation jank.