### PR TITLE
Save Transitions to use for back navigation

### DIFF
--- a/magellan-library/src/main/java/com/wealthfront/magellan/Navigator.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/Navigator.java
@@ -548,8 +548,18 @@ public class Navigator implements BackHandler {
   private void animateAndRemove(
       final View from, final View to, final NavigationType navType, final Direction direction) {
     ghostView = from;
-    final Transition transitionToUse = overridingTransition != null ? overridingTransition : transition;
-    overridingTransition = null;
+    Transition currentTransition = transition;
+    if (overridingTransition != null) {
+      currentTransition = overridingTransition;
+      overridingTransition = null;
+    } else if (direction.equals(Direction.BACKWARD) && currentScreen().getLeaveTransition() != null) {
+      currentTransition = currentScreen().getLeaveTransition();
+      currentScreen().setLeaveTransition(null);
+    }
+    if (direction.equals(Direction.FORWARD)) {
+      currentScreen().setLeaveTransition(currentTransition);
+    }
+    final Transition transitionToUse = currentTransition;
     whenMeasured(to, new Views.OnMeasured() {
       @Override
       public void onMeasured() {

--- a/magellan-library/src/main/java/com/wealthfront/magellan/Screen.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/Screen.java
@@ -12,6 +12,8 @@ import android.util.SparseArray;
 import android.view.Menu;
 import android.view.ViewGroup;
 
+import com.wealthfront.magellan.transitions.Transition;
+
 import static com.wealthfront.magellan.Preconditions.checkState;
 
 /**
@@ -46,6 +48,7 @@ public abstract class Screen<V extends ViewGroup & ScreenView> implements BackHa
   private boolean dialogIsShowing;
   private Dialog dialog;
   private SparseArray<Parcelable> viewState;
+  private Transition leaveTransition;
 
   /**
    * @return the View associated with this Screen or null if we are not in between {@link #onShow(Context)} and\
@@ -127,6 +130,14 @@ public abstract class Screen<V extends ViewGroup & ScreenView> implements BackHa
       dialog.dismiss();
       dialog = null;
     }
+  }
+
+  final Transition getLeaveTransition() {
+    return leaveTransition;
+  }
+
+  final void setLeaveTransition(Transition leaveTransition) {
+    this.leaveTransition = leaveTransition;
   }
 
   /**

--- a/magellan-library/src/main/java/com/wealthfront/magellan/Screen.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/Screen.java
@@ -132,11 +132,11 @@ public abstract class Screen<V extends ViewGroup & ScreenView> implements BackHa
     }
   }
 
-  final Transition getLeaveTransition() {
+  Transition getLeaveTransition() {
     return leaveTransition;
   }
 
-  final void setLeaveTransition(Transition leaveTransition) {
+  void setLeaveTransition(Transition leaveTransition) {
     this.leaveTransition = leaveTransition;
   }
 

--- a/magellan-library/src/test/java/com/wealthfront/magellan/NavigatorTest.java
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/NavigatorTest.java
@@ -494,14 +494,17 @@ public class NavigatorTest {
   @Test
   public void setLeaveTransition() {
     navigator.onCreate(activity, null);
-    Transition leaveTransition = new NoAnimationTransition();
-    when(screen.getLeaveTransition()).thenReturn(new NoAnimationTransition());
 
     navigator.goTo(screen);
 
     verify(screen).setLeaveTransition(isA(NoAnimationTransition.class));
+  }
 
-    reset(screen);
+  @Test
+  public void setLeaveTransition_overrideTransition() {
+    navigator.onCreate(activity, null);
+    Transition leaveTransition = new NoAnimationTransition();
+
     navigator.overrideTransition(leaveTransition);
     navigator.goTo(screen);
 

--- a/magellan-library/src/test/java/com/wealthfront/magellan/NavigatorTest.java
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/NavigatorTest.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.view.View;
 
 import com.wealthfront.magellan.transitions.NoAnimationTransition;
+import com.wealthfront.magellan.transitions.Transition;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -488,6 +489,37 @@ public class NavigatorTest {
         "GO BACKWARD - Backstack: root > screen > [screen2]\n" +
         "SHOW FORWARD - Backstack: root > screen > screen2 > [screen3]\n"
     );
+  }
+
+  @Test
+  public void setLeaveTransition() {
+    navigator.onCreate(activity, null);
+    Transition leaveTransition = new NoAnimationTransition();
+    when(screen.getLeaveTransition()).thenReturn(new NoAnimationTransition());
+
+    navigator.goTo(screen);
+
+    verify(screen).setLeaveTransition(isA(NoAnimationTransition.class));
+
+    reset(screen);
+    navigator.overrideTransition(leaveTransition);
+    navigator.goTo(screen);
+
+    verify(screen).setLeaveTransition(leaveTransition);
+  }
+
+  @Test
+  public void useLeaveTransition() {
+    navigator.onCreate(activity, null);
+    Transition leaveTransition = spy(new NoAnimationTransition());
+    when(screen.getLeaveTransition()).thenReturn(leaveTransition);
+
+    navigator.goTo(screen);
+    navigator.goBack();
+
+    verify(leaveTransition).animate(isA(View.class), isA(View.class), isA(NavigationType.class), Direction.BACKWARD,
+        isA(Transition.Callback.class));
+    verify(screen).setLeaveTransition(null);
   }
 
   private static class NavigatorActivity extends Activity implements NavigationListener {

--- a/magellan-library/src/test/java/com/wealthfront/magellan/NavigatorTest.java
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/NavigatorTest.java
@@ -511,20 +511,6 @@ public class NavigatorTest {
     verify(screen).setLeaveTransition(leaveTransition);
   }
 
-  @Test
-  public void useLeaveTransition() {
-    navigator.onCreate(activity, null);
-    Transition leaveTransition = spy(new NoAnimationTransition());
-    when(screen.getLeaveTransition()).thenReturn(leaveTransition);
-
-    navigator.goTo(screen);
-    navigator.goBack();
-
-    verify(leaveTransition).animate(isA(View.class), isA(View.class), isA(NavigationType.class), Direction.BACKWARD,
-        isA(Transition.Callback.class));
-    verify(screen).setLeaveTransition(null);
-  }
-
   private static class NavigatorActivity extends Activity implements NavigationListener {
 
     ActionBarConfig actionBarConfig;


### PR DESCRIPTION
Saving transitions allow us to create interesting transitions later, in addition to just making sense. I'd rather not have to override back transitions too.

Saving transitions can be tricky when you can rewrite the backstack, so I decided to attach Transitions to screens so they can animate out in the same method they animate in. A mutable backstack in this case means that transitions must work with any to/from view, which is a reasonable restriction in my mind.