### PR TITLE
Support activity title modification

### DIFF
--- a/magellan-library/src/main/java/com/wealthfront/magellan/Navigator.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/Navigator.java
@@ -634,6 +634,11 @@ public class Navigator implements BackHandler {
     }
   }
 
+  public void invalidateTitle() {
+    Screen currentScreen = currentScreen();
+    activity.setTitle(currentScreen.getTitle(activity));
+  }
+
   private boolean sameActivity(Activity activity) {
     return this.activity == activity;
   }

--- a/magellan-library/src/main/java/com/wealthfront/magellan/Navigator.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/Navigator.java
@@ -579,7 +579,7 @@ public class Navigator implements BackHandler {
     View view = currentScreen.recreateView(activity, this);
     container.addView(view, direction == FORWARD ? container.getChildCount() : 0);
     currentScreen.createDialog();
-    activity.setTitle(currentScreen.getTitle(activity));
+    invalidateTitle();
     currentScreen.onShow(activity);
     for (ScreenLifecycleListener lifecycleListener : lifecycleListeners) {
       lifecycleListener.onShow(currentScreen);

--- a/magellan-library/src/test/java/com/wealthfront/magellan/NavigatorTest.java
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/NavigatorTest.java
@@ -261,6 +261,19 @@ public class NavigatorTest {
     assertThat(navigator.currentScreen()).isEqualTo(screen);
   }
 
+  @Test
+  public void invalidateTitle() {
+    navigator.onCreate(activity, null);
+
+    when(screen.getTitle(activity)).thenReturn("Old Screen Title");
+    navigator.goTo(screen);
+    verify(activity).setTitle("Old Screen Title");
+
+    when(screen.getTitle(activity)).thenReturn("New Screen Title");
+    navigator.invalidateTitle();
+    verify(activity).setTitle("New Screen Title");
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void goBackBefore_screenNotInHistory() {
     navigator.onCreate(activity, null);


### PR DESCRIPTION
notify navigator when the data backing its title has changed. 

For example, if the formula for your activity title is something like `user.getName()`, you'd likely want the title to be refreshed each time the user's name changes.