### PR TITLE
Added ScreenAwareActivity to add flexibility to use other Activities.

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="EntryPointsManager">
-    <entry_points version="2.0" />
-  </component>
   <component name="NullableNotNullManager">
     <option name="myDefaultNullable" value="android.support.annotation.Nullable" />
     <option name="myDefaultNotNull" value="android.support.annotation.NonNull" />
@@ -27,20 +24,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectLevelVcsManager" settingsEditedManually="false">
-    <OptionsSetting value="true" id="Add" />
-    <OptionsSetting value="true" id="Remove" />
-    <OptionsSetting value="true" id="Checkout" />
-    <OptionsSetting value="true" id="Update" />
-    <OptionsSetting value="true" id="Status" />
-    <OptionsSetting value="true" id="Edit" />
-    <ConfirmationsSetting value="0" id="Add" />
-    <ConfirmationsSetting value="0" id="Remove" />
-  </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
-  </component>
-  <component name="ProjectType">
-    <option name="id" value="Android" />
   </component>
 </project>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.wealthfront
-VERSION_NAME=1.0.0
+VERSION_NAME=1.0.1
 
 POM_DESCRIPTION=The simplest navigation library for Android
 

--- a/magellan-library/build.gradle
+++ b/magellan-library/build.gradle
@@ -39,7 +39,6 @@ dependencies {
     exclude group: 'commons-logging', module: 'commons-logging'
     exclude group: 'org.apache.httpcomponents', module: 'httpclient'
   }
-
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/magellan-library/src/main/java/com/wealthfront/magellan/Navigator.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/Navigator.java
@@ -23,537 +23,537 @@ import static com.wealthfront.magellan.Direction.FORWARD;
 import static com.wealthfront.magellan.NavigationType.GO;
 import static com.wealthfront.magellan.NavigationType.NO_ANIM;
 import static com.wealthfront.magellan.NavigationType.SHOW;
-import static com.wealthfront.magellan.Views.whenMeasured;
 import static com.wealthfront.magellan.Preconditions.checkArgument;
 import static com.wealthfront.magellan.Preconditions.checkNotNull;
 import static com.wealthfront.magellan.Preconditions.checkState;
+import static com.wealthfront.magellan.Views.whenMeasured;
 
 /**
  * Class responsible for navigating between screens and maintaining collection of screens in a back stack.
  */
 public class Navigator implements BackHandler {
 
-  private final Deque<Screen> backStack = new ArrayDeque<>();
-  private Activity activity;
-  private Menu menu;
-  private ScreenContainer container;
-  private final Transition transition;
-  private Transition overridingTransition;
-  private final List<ScreenLifecycleListener> lifecycleListeners = new ArrayList<>();
-  private View ghostView; // keep track of the disappearing view we are animating
-  private boolean loggingEnabled;
-  private EventTracker eventTracker;
+    private final Deque<Screen> backStack = new ArrayDeque<>();
+    private ScreenAwareActivity activity;
+    private Menu menu;
+    private ScreenContainer container;
+    private final Transition transition;
+    private Transition overridingTransition;
+    private final List<ScreenLifecycleListener> lifecycleListeners = new ArrayList<>();
+    private View ghostView; // keep track of the disappearing view we are animating
+    private boolean loggingEnabled;
+    private EventTracker eventTracker;
 
-  public static Builder withRoot(Screen root) {
-    return new Builder(root);
-  }
-
-  Navigator(Builder builder) {
-    backStack.push(builder.root);
-    transition = builder.transition;
-    loggingEnabled = builder.loggingEnabled;
-    eventTracker = new EventTracker(builder.maxEventsTracked);
-  }
-
-  /**
-   * Adds a lifecycle listener that will be notified when each Screen is shown and hidden.
-   *
-   * @param lifecycleListener  Listener that receives screen lifecycle events
-   */
-  public void addLifecycleListener(ScreenLifecycleListener lifecycleListener) {
-    lifecycleListeners.add(lifecycleListener);
-  }
-
-  /**
-   * Unregisters a Screen lifecycle listener. Removed listener will no longer receive screen lifecycle
-   * callbacks.
-   *
-   * @param lifecycleListener  listener to unregister from receiving screen lifecycle events
-   */
-  public void removeLifecycleListener(ScreenLifecycleListener lifecycleListener) {
-    lifecycleListeners.remove(lifecycleListener);
-  }
-
-  /**
-   * Initializes the Navigator with Activity instance and Bundle for saved instance state.
-   *
-   * Call this method from {@link Activity#onCreate(Bundle) onCreate} of the Activity associated with this Navigator.
-   *
-   * @param activity  Activity associated with application
-   * @param savedInstanceState  state to restore from previously destroyed activity
-   * @throws IllegalStateException when no {@link ScreenContainer} view present in hierarchy with view id of container
-   */
-  public void onCreate(Activity activity, Bundle savedInstanceState) {
-    this.activity = activity;
-    container = (ScreenContainer) activity.findViewById(R.id.magellan_container);
-    checkState(container != null, "There must be a ScreenContainer whose id is R.id.magellan_container in the view hierarchy");
-    for (Screen screen : backStack) {
-      screen.restore(savedInstanceState);
-      screen.onRestore(savedInstanceState);
+    public static Builder withRoot(Screen root) {
+        return new Builder(root);
     }
-    showCurrentScreen(FORWARD);
-  }
 
-  /**
-   * Notifies all screens to save instance state in input Bundle.
-   *
-   * Call this method from {@link Activity#onSaveInstanceState(Bundle) onSaveInstanceState} in the Activity associated
-   * with this Navigator
-   *
-   * @param outState  Bundle in which to store screen state information
-   */
-  public void onSaveInstanceState(Bundle outState) {
-    for (Screen screen : backStack) {
-      screen.save(outState);
-      screen.onSave(outState);
+    Navigator(Builder builder) {
+        backStack.push(builder.root);
+        transition = builder.transition;
+        loggingEnabled = builder.loggingEnabled;
+        eventTracker = new EventTracker(builder.maxEventsTracked);
     }
-  }
 
-  /**
-   * Attaches options menu to Navigator to allow Screens to control which items are shown/hidden.
-   *
-   * All menu items are hidden by default.
-   *
-   * Call this method from {@link Activity#onCreateOptionsMenu(Menu) onCreateOptionsMenu} in the Activity associated
-   * with this Navigator
-   *
-   * @param menu  options menu to be controlled by current screen
-   */
-  public void onCreateOptionsMenu(Menu menu) {
-    this.menu = menu;
-    updateMenu();
-  }
-
-  /**
-   * Updates options menu to Navigator to allow Screens to update which items are shown/hidden.
-   *
-   * All menu items are hidden by default.
-   *
-   * Call this method from {@link Activity#onPrepareOptionsMenu(Menu) onPrepareOptionsMenu} in the Activity associated
-   * with this Navigator
-   *
-   * @param menu  options menu to be updated by current screen
-   */
-  public void onPrepareOptionsMenu(Menu menu) {
-    this.menu = menu;
-    updateMenu();
-  }
-
-  /**
-   * Notifies Navigator that the activity's onResume lifecycle callback has been hit. Call this method from
-   * {@code onResume} of the Activity associated with this Navigator.
-   *
-   * This method will notify the current screen of the lifecycle event if the activity parameter is the same as the
-   * activity provided to this Navigator in {@link #onCreate(Activity, Bundle) onCreate}.
-   *
-   * @param activity  activity that received onResume callback
-   */
-  public void onResume(Activity activity) {
-    if (sameActivity(activity)) {
-      currentScreen().onResume(activity);
+    /**
+     * Adds a lifecycle listener that will be notified when each Screen is shown and hidden.
+     *
+     * @param lifecycleListener Listener that receives screen lifecycle events
+     */
+    public void addLifecycleListener(ScreenLifecycleListener lifecycleListener) {
+        lifecycleListeners.add(lifecycleListener);
     }
-  }
 
-  /**
-   * Notifies Navigator that the activity's onPause lifecycle callback has been hit. Call this method from
-   * {@link Activity#onPause() onPause} of the Activity associated with this Navigator.
-   *
-   * This method will notify the current screen of the lifecycle event if the activity parameter is the same as the
-   * activity provided to this Navigator in {@link #onCreate(Activity, Bundle) onCreate}.
-   *
-   * @param activity  activity that received onPause callback
-   */
-  public void onPause(Activity activity) {
-    if (sameActivity(activity)) {
-      currentScreen().onPause(activity);
+    /**
+     * Unregisters a Screen lifecycle listener. Removed listener will no longer receive screen lifecycle
+     * callbacks.
+     *
+     * @param lifecycleListener listener to unregister from receiving screen lifecycle events
+     */
+    public void removeLifecycleListener(ScreenLifecycleListener lifecycleListener) {
+        lifecycleListeners.remove(lifecycleListener);
     }
-  }
 
-  /**
-   * Notifies Navigator that the activity's onDestroy lifecycle callback has been hit. Call this method from
-   * {@link Activity#onDestroy() onDestroy} of the Activity associated with this Navigator.
-   *
-   * This method will hid the current screen, and clear references to this Navigators associated activity, menu, and
-   * container view, if the activity parameter is the same as the activity provided to this Navigator in
-   * {@link #onCreate(Activity, Bundle) onCreate}.
-   *
-   * @param activity  activity that received onDestroy callback
-   */
-  public void onDestroy(Activity activity) {
-    if (sameActivity(activity)) {
-      hideCurrentScreen();
-      this.activity = null;
-      container = null;
-      menu = null;
+    /**
+     * Initializes the Navigator with Activity instance and Bundle for saved instance state.
+     * <p>
+     * Call this method from {@link Activity#onCreate(Bundle) onCreate} of the Activity associated with this Navigator.
+     *
+     * @param activity           Activity associated with application
+     * @param savedInstanceState state to restore from previously destroyed activity
+     * @throws IllegalStateException when no {@link ScreenContainer} view present in hierarchy with view id of container
+     */
+    public void onCreate(ScreenAwareActivity activity, Bundle savedInstanceState) {
+        this.activity = activity;
+        container = (ScreenContainer) activity.findViewById(R.id.magellan_container);
+        checkState(container != null, "There must be a ScreenContainer whose id is R.id.magellan_container in the view hierarchy");
+        for (Screen screen : backStack) {
+            screen.restore(savedInstanceState);
+            screen.onRestore(savedInstanceState);
+        }
+        showCurrentScreen(FORWARD);
     }
-  }
 
-  /**
-   * Handles back button press by user. Notifies current screen on back button press and allows screen to handle
-   * back press itself. If the current screen does not handle back press, and this Navigator has more than one screen,
-   * this Navigator will remove the current screen from its collection of screens and display the previous screen.
-   * If this Navigator only has one Screen when it receives a call to {@link #handleBack()} it will not handle the back
-   * button press.
-   *
-   * Call this method from within {@link Activity#onBackPressed()} of the activity associated with this Navigator.
-   *
-   * (Example usage) In the Activity class associated with this Navigator, put:
-   * <pre> <code>
-   * {@literal @}Override
-   * public void onBackPressed() {
-   *   if (!navigator.handleBack()) {
-   *     super.onBackPressed();
-   *   }
-   * }
-   * </code> </pre>
-   *
-   * @return true if the Navigator consumed the back button click
-   */
-  @Override
-  public boolean handleBack() {
-    Screen currentScreen = currentScreen();
-    if (currentScreen.handleBack()) {
-      return true;
-    } else {
-      if (!atRoot()) {
-        goBack();
-        return true;
-      } else {
-        return false;
-      }
+    /**
+     * Notifies all screens to save instance state in input Bundle.
+     * <p>
+     * Call this method from {@link Activity#onSaveInstanceState(Bundle) onSaveInstanceState} in the Activity associated
+     * with this Navigator
+     *
+     * @param outState Bundle in which to store screen state information
+     */
+    public void onSaveInstanceState(Bundle outState) {
+        for (Screen screen : backStack) {
+            screen.save(outState);
+            screen.onSave(outState);
+        }
     }
-  }
 
-  /**
-   * Gets the screen on top of this Navigator's back stack.
-   *
-   * @return the current screen in the back stack
-   */
-  public Screen currentScreen() {
-    checkBackStackNotEmpty();
-    return backStack.peek();
-  }
+    /**
+     * Attaches options menu to Navigator to allow Screens to control which items are shown/hidden.
+     * <p>
+     * All menu items are hidden by default.
+     * <p>
+     * Call this method from {@link Activity#onCreateOptionsMenu(Menu) onCreateOptionsMenu} in the Activity associated
+     * with this Navigator
+     *
+     * @param menu options menu to be controlled by current screen
+     */
+    public void onCreateOptionsMenu(Menu menu) {
+        this.menu = menu;
+        updateMenu();
+    }
 
-  /**
-   * Returns true if this Navigator is at its root screen, false otherwise.
-   *
-   * @return true if this Navigator is at its root screen, false otherwise.
-   */
-  public boolean atRoot() {
-    return backStack.size() == 1;
-  }
+    /**
+     * Updates options menu to Navigator to allow Screens to update which items are shown/hidden.
+     * <p>
+     * All menu items are hidden by default.
+     * <p>
+     * Call this method from {@link Activity#onPrepareOptionsMenu(Menu) onPrepareOptionsMenu} in the Activity associated
+     * with this Navigator
+     *
+     * @param menu options menu to be updated by current screen
+     */
+    public void onPrepareOptionsMenu(Menu menu) {
+        this.menu = menu;
+        updateMenu();
+    }
 
-  /**
-   * Clears the back stack of this Navigator and adds the input Screen as the new root of the back stack.
-   *
-   * @param activity  activity used to verify this Navigator is in an acceptable state when resetWithRoot is called
-   * @param root  new root screen for this Navigator
-   * @throws IllegalStateException if {@link #onCreate(Activity, Bundle)} has already been called on this Navigator
-   */
-  public void resetWithRoot(Activity activity, final Screen root) {
-    checkOnCreateNotYetCalled(activity, "resetWithRoot() must be called before onCreate()");
-    backStack.clear();
-    backStack.push(root);
-  }
+    /**
+     * Notifies Navigator that the activity's onResume lifecycle callback has been hit. Call this method from
+     * {@code onResume} of the Activity associated with this Navigator.
+     * <p>
+     * This method will notify the current screen of the lifecycle event if the activity parameter is the same as the
+     * activity provided to this Navigator in {@link (Activity, Bundle) onCreate}.
+     *
+     * @param activity activity that received onResume callback
+     */
+    public void onResume(ScreenAwareActivity activity) {
+        if (sameActivity(activity)) {
+            currentScreen().onResume(activity.getContext());
+        }
+    }
 
-  /**
-   * Change the elements of the back stack according to the implementation of the HistoryRewriter parameter.
-   * <b>Note, this method cannot be called after calling {@link #onCreate(Activity, Bundle)} on this Navigator.</b> The
-   * primary use case for this method is to change the back stack before the navigator is fully initialized (e.g.
-   * showing a login screen if necessary). It is possible to manipulate the back stack with a {@link HistoryRewriter},
-   * {@link #navigate(HistoryRewriter)}.
-   *
-   * @param activity  activity used to verify this Navigator is in an acceptable state when resetWithRoot is called
-   * @param historyRewriter  rewrites back stack to desired state
-   * @throws IllegalStateException if {@link #onCreate(Activity, Bundle)} has already been called on this Navigator
-   */
-  public void rewriteHistory(Activity activity, HistoryRewriter historyRewriter) {
-    checkOnCreateNotYetCalled(activity, "rewriteHistory() must be called before onCreate()");
-    historyRewriter.rewriteHistory(backStack);
-  }
+    /**
+     * Notifies Navigator that the activity's onPause lifecycle callback has been hit. Call this method from
+     * {@link Activity#onPause() onPause} of the Activity associated with this Navigator.
+     * <p>
+     * This method will notify the current screen of the lifecycle event if the activity parameter is the same as the
+     * activity provided to this Navigator in {@link (Activity, Bundle) onCreate}.
+     *
+     * @param activity activity that received onPause callback
+     */
+    public void onPause(ScreenAwareActivity activity) {
+        if (sameActivity(activity)) {
+            currentScreen().onPause(activity.getContext());
+        }
+    }
 
-  /**
-   * Navigates to the screen on top of the back stack after the HistoryRewriter has rewritten the back stack history.
-   *
-   * Does not animate during navigation.
-   *
-   * @param historyRewriter  manipulates the back stack during navigation
-   */
-  public void navigate(final HistoryRewriter historyRewriter) {
-    navigate(historyRewriter, NO_ANIM);
-  }
+    /**
+     * Notifies Navigator that the activity's onDestroy lifecycle callback has been hit. Call this method from
+     * {@link Activity#onDestroy() onDestroy} of the Activity associated with this Navigator.
+     * <p>
+     * This method will hid the current screen, and clear references to this Navigators associated activity, menu, and
+     * container view, if the activity parameter is the same as the activity provided to this Navigator in
+     * {@link (Activity, Bundle) onCreate}.
+     *
+     * @param activity activity that received onDestroy callback
+     */
+    public void onDestroy(ScreenAwareActivity activity) {
+        if (sameActivity(activity)) {
+            hideCurrentScreen();
+            this.activity = null;
+            container = null;
+            menu = null;
+        }
+    }
 
-  /**
-   * Navigates to the screen on top of the back stack after the HistoryRewriter has rewritten the back stack history.
-   *
-   * Animates the navigation according to the NavigationType parameter.
-   *
-   * @param historyRewriter  manipulates the back stack during navigation
-   * @param navType  controls how the new screen is displayed to the user
-   */
-  public void navigate(final HistoryRewriter historyRewriter, NavigationType navType) {
-    navigate(FORWARD, navType, new Runnable() {
-      @Override
-      public void run() {
+    /**
+     * Handles back button press by user. Notifies current screen on back button press and allows screen to handle
+     * back press itself. If the current screen does not handle back press, and this Navigator has more than one screen,
+     * this Navigator will remove the current screen from its collection of screens and display the previous screen.
+     * If this Navigator only has one Screen when it receives a call to {@link #handleBack()} it will not handle the back
+     * button press.
+     * <p>
+     * Call this method from within {@link Activity#onBackPressed()} of the activity associated with this Navigator.
+     * <p>
+     * (Example usage) In the Activity class associated with this Navigator, put:
+     * <pre> <code>
+     * {@literal @}Override
+     * public void onBackPressed() {
+     *   if (!navigator.handleBack()) {
+     *     super.onBackPressed();
+     *   }
+     * }
+     * </code> </pre>
+     *
+     * @return true if the Navigator consumed the back button click
+     */
+    @Override
+    public boolean handleBack() {
+        Screen currentScreen = currentScreen();
+        if (currentScreen.handleBack()) {
+            return true;
+        } else {
+            if (!atRoot()) {
+                goBack();
+                return true;
+            } else {
+                return false;
+            }
+        }
+    }
+
+    /**
+     * Gets the screen on top of this Navigator's back stack.
+     *
+     * @return the current screen in the back stack
+     */
+    public Screen currentScreen() {
+        checkBackStackNotEmpty();
+        return backStack.peek();
+    }
+
+    /**
+     * Returns true if this Navigator is at its root screen, false otherwise.
+     *
+     * @return true if this Navigator is at its root screen, false otherwise.
+     */
+    public boolean atRoot() {
+        return backStack.size() == 1;
+    }
+
+    /**
+     * Clears the back stack of this Navigator and adds the input Screen as the new root of the back stack.
+     *
+     * @param activity activity used to verify this Navigator is in an acceptable state when resetWithRoot is called
+     * @param root     new root screen for this Navigator
+     * @throws IllegalStateException if {@link (Activity, Bundle)} has already been called on this Navigator
+     */
+    public void resetWithRoot(ScreenAwareActivity activity, final Screen root) {
+        checkOnCreateNotYetCalled(activity, "resetWithRoot() must be called before onCreate()");
+        backStack.clear();
+        backStack.push(root);
+    }
+
+    /**
+     * Change the elements of the back stack according to the implementation of the HistoryRewriter parameter.
+     * <b>Note, this method cannot be called after calling {@link (Activity, Bundle)} on this Navigator.</b> The
+     * primary use case for this method is to change the back stack before the navigator is fully initialized (e.g.
+     * showing a login screen if necessary). It is possible to manipulate the back stack with a {@link HistoryRewriter},
+     * {@link #navigate(HistoryRewriter)}.
+     *
+     * @param activity        activity used to verify this Navigator is in an acceptable state when resetWithRoot is called
+     * @param historyRewriter rewrites back stack to desired state
+     * @throws IllegalStateException if {@link (Activity, Bundle)} has already been called on this Navigator
+     */
+    public void rewriteHistory(ScreenAwareActivity activity, HistoryRewriter historyRewriter) {
+        checkOnCreateNotYetCalled(activity, "rewriteHistory() must be called before onCreate()");
         historyRewriter.rewriteHistory(backStack);
-      }
-    });
-  }
-
-  /**
-   * Navigates to the screen on top of the back stack after the HistoryRewriter has rewritten the back stack history.
-   *
-   * Animates the navigation according to the NavigationType parameter, in the direction specified by the Direction
-   * parameter.
-   *
-   * @param historyRewriter  manipulates the back stack during navigation
-   * @param navType  controls how the new screen is displayed to the user
-   * @param direction  controls the direction in which the new screen moves in and old screen moves out during navigation
-   */
-  public void navigate(final HistoryRewriter historyRewriter, NavigationType navType, Direction direction) {
-    navigate(direction, navType, new Runnable() {
-      @Override
-      public void run() {
-        historyRewriter.rewriteHistory(backStack);
-      }
-    });
-  }
-
-  /**
-   * Replaces screen on top of the back stack with the new screen. When navigation completes, previous screen on top of
-   * the back stack will have been removed, and the Screen parameter will be the new top screen on the back stack.
-   *
-   * @param screen  new top screen on back stack
-   */
-  public void replace(Screen screen) {
-    replace(screen, GO);
-  }
-
-  /**
-   * Replaces screen on top of the back stack with the new screen without animation. When navigation completes,
-   * previous screen on top of the back stack will have been removed, and the Screen parameter will be the new top
-   * screen on the back stack.
-   *
-   * @param screen  new top screen on back stack
-   */
-  public void replaceNow(Screen screen) {
-    replace(screen, NO_ANIM);
-  }
-
-  /**
-   * Shows new screen by animating screen to slide up from bottom of container to cover previous screen. When navigation
-   * completes, the Screen parameter will be on top of this Navigator's back stack.
-   *
-   * If the current screen is already being shown, as determined by {@code currentScreen().equals(screen)}, this method
-   * will do nothing.
-   *
-   * @param screen  new top screen on back stack
-   */
-  public void show(Screen screen) {
-    show(screen, SHOW);
-  }
-
-  /**
-   * Shows new screen without animating the navigation event. When navigation completes, the Screen parameter will be
-   * on top of this Navigator's back stack.
-   *
-   * If the current screen is already being shown, this method will do nothing.
-   *
-   * @param screen  new top screen on back stack
-   */
-  public void showNow(Screen screen) {
-    show(screen, NO_ANIM);
-  }
-
-  private void show(Screen screen, NavigationType navType) {
-    if (!isCurrentScreen(screen)) {
-      navigateTo(screen, navType);
     }
-  }
 
-  /**
-   * Navigates back to previous screen if Screen parameter is currently the top screen on this Navigator's back stack.
-   * If the Screen parameter is not the top screen on the back stack, this method does nothing.
-   *
-   * @param screen  screen to hide
-   */
-  public void hide(Screen screen) {
-    if (isCurrentScreen(screen)) {
-      navigateBack(SHOW);
+    /**
+     * Navigates to the screen on top of the back stack after the HistoryRewriter has rewritten the back stack history.
+     * <p>
+     * Does not animate during navigation.
+     *
+     * @param historyRewriter manipulates the back stack during navigation
+     */
+    public void navigate(final HistoryRewriter historyRewriter) {
+        navigate(historyRewriter, NO_ANIM);
     }
-  }
 
-  /**
-   * Returns true if the Screen parameter is the current screen on top of this Navigator's back stack, false otherwise.
-   * Equality is determined using {@code Screen#equals(Object)}.
-   *
-   * @param screen screen to check if it is currently on top of this Navigator's back stack
-   * @return true if the Screen parameter is the top screen on this Navigator's back stack
-   */
-  public boolean isCurrentScreen(Screen screen) {
-    return !backStack.isEmpty() && currentScreen().equals(screen);
-  }
+    /**
+     * Navigates to the screen on top of the back stack after the HistoryRewriter has rewritten the back stack history.
+     * <p>
+     * Animates the navigation according to the NavigationType parameter.
+     *
+     * @param historyRewriter manipulates the back stack during navigation
+     * @param navType         controls how the new screen is displayed to the user
+     */
+    public void navigate(final HistoryRewriter historyRewriter, NavigationType navType) {
+        navigate(FORWARD, navType, new Runnable() {
+            @Override
+            public void run() {
+                historyRewriter.rewriteHistory(backStack);
+            }
+        });
+    }
 
-  /**
-   * Navigates to the Screen parameter. Animates current top screen on this Navigator's back stack out to the left and
-   * slides the Screen parameter screen in from the right. At the end of the navigation event, the Screen parameter will
-   * be the top screen on this Navigator's back stack.
-   *
-   * @param screen  new top screen for this Navigator's back stack
-   */
-  public void goTo(Screen screen) {
-    navigateTo(screen, GO);
-  }
+    /**
+     * Navigates to the screen on top of the back stack after the HistoryRewriter has rewritten the back stack history.
+     * <p>
+     * Animates the navigation according to the NavigationType parameter, in the direction specified by the Direction
+     * parameter.
+     *
+     * @param historyRewriter manipulates the back stack during navigation
+     * @param navType         controls how the new screen is displayed to the user
+     * @param direction       controls the direction in which the new screen moves in and old screen moves out during navigation
+     */
+    public void navigate(final HistoryRewriter historyRewriter, NavigationType navType, Direction direction) {
+        navigate(direction, navType, new Runnable() {
+            @Override
+            public void run() {
+                historyRewriter.rewriteHistory(backStack);
+            }
+        });
+    }
 
-  /**
-   * Navigates from current screen to previous screen in this Navigator's back stack. Current screen animates out of the
-   * view by sliding out to the right and the next screen in the back stack slides in from the left.
-   *
-   * @throws IllegalStateException if this Navigator only has one screen in its back stack
-   */
-  public void goBack() {
-    checkState(!atRoot(), "Can't go back, this is the last screen. Did you mean to call handleBack() instead?");
-    navigateBack(GO);
-  }
+    /**
+     * Replaces screen on top of the back stack with the new screen. When navigation completes, previous screen on top of
+     * the back stack will have been removed, and the Screen parameter will be the new top screen on the back stack.
+     *
+     * @param screen new top screen on back stack
+     */
+    public void replace(Screen screen) {
+        replace(screen, GO);
+    }
 
-  /**
-   * Navigates from current screen all the way to the root screen in this Navigator's back stack, removing all
-   * intermediate screen in this Navigator's back stack along the way. The current screen animates out of the view
-   * according to the animation specified by the NavigationType parameter.
-   *
-   * @param navigationType  determines how the navigation event is animated
-   */
-  public void goBackToRoot(NavigationType navigationType) {
-    navigate(new HistoryRewriter() {
-      @Override
-      public void rewriteHistory(Deque<Screen> history) {
-        while (history.size() > 1) {
-          history.pop();
+    /**
+     * Replaces screen on top of the back stack with the new screen without animation. When navigation completes,
+     * previous screen on top of the back stack will have been removed, and the Screen parameter will be the new top
+     * screen on the back stack.
+     *
+     * @param screen new top screen on back stack
+     */
+    public void replaceNow(Screen screen) {
+        replace(screen, NO_ANIM);
+    }
+
+    /**
+     * Shows new screen by animating screen to slide up from bottom of container to cover previous screen. When navigation
+     * completes, the Screen parameter will be on top of this Navigator's back stack.
+     * <p>
+     * If the current screen is already being shown, as determined by {@code currentScreen().equals(screen)}, this method
+     * will do nothing.
+     *
+     * @param screen new top screen on back stack
+     */
+    public void show(Screen screen) {
+        show(screen, SHOW);
+    }
+
+    /**
+     * Shows new screen without animating the navigation event. When navigation completes, the Screen parameter will be
+     * on top of this Navigator's back stack.
+     * <p>
+     * If the current screen is already being shown, this method will do nothing.
+     *
+     * @param screen new top screen on back stack
+     */
+    public void showNow(Screen screen) {
+        show(screen, NO_ANIM);
+    }
+
+    private void show(Screen screen, NavigationType navType) {
+        if (!isCurrentScreen(screen)) {
+            navigateTo(screen, navType);
         }
-      }
-    }, navigationType, BACKWARD);
-  }
+    }
 
-  /**
-   * Navigates from the current screen back to the Screen parameter wherever it is in this Navigator's back stack.
-   * Screens in between the current screen and the Screen parameter on the back stack are removed. If the Screen
-   * parameter is not present in this Navigator's back stack, this method is equivalent to
-   * {@link #goBackToRoot(NavigationType) goBackToRoot(NavigationType.GO)}
-   *
-   * @param screen  screen to navigate back to through this Navigator's back stack
-   */
-  public void goBackTo(final Screen screen) {
-    goBackTo(screen, GO);
-  }
-
-  /**
-   * Navigates from the current screen back to the Screen parameter wherever it is in this Navigator's back stack.
-   * Screens in between the current screen and the Screen parameter on the back stack are removed. If the Screen
-   * parameter is not present in this Navigator's back stack, this method is equivalent to
-   * {@link #goBackToRoot(NavigationType) goBackToRoot(navigationType)}
-   *
-   * @param screen  screen to navigate back to through this Navigator's back stack
-   * @param navigationType  determines how the navigation event is animated
-   */
-  public void goBackTo(final Screen screen, NavigationType navigationType) {
-    navigate(new HistoryRewriter() {
-      @Override
-      public void rewriteHistory(Deque<Screen> history) {
-        checkArgument(history.contains(screen), "Can't go back to a screen that isn't in history.");
-        while (history.size() > 1) {
-          if (history.peek() == screen) {
-            break;
-          }
-          history.pop();
+    /**
+     * Navigates back to previous screen if Screen parameter is currently the top screen on this Navigator's back stack.
+     * If the Screen parameter is not the top screen on the back stack, this method does nothing.
+     *
+     * @param screen screen to hide
+     */
+    public void hide(Screen screen) {
+        if (isCurrentScreen(screen)) {
+            navigateBack(SHOW);
         }
-      }
-    }, navigationType, BACKWARD);
-  }
+    }
 
-  /**
-   * Navigates from the current screen back to the screen in this Navigator's back stack immediately before the
-   * Screen parameter. Screens in between the current screen and the Screen parameter on the back stack are removed.
-   * If the Screen parameter is not present in this Navigator's back stack, this method is equivalent to
-   * {@link #goBackToRoot(NavigationType) goBackToRoot(NavigationType.GO)}
-   *
-   * @param screen  screen to navigate back to through this Navigator's back stack
-   */
-  public void goBackBefore(Screen screen) {
-    goBackBefore(screen, GO);
-  }
+    /**
+     * Returns true if the Screen parameter is the current screen on top of this Navigator's back stack, false otherwise.
+     * Equality is determined using {@code Screen#equals(Object)}.
+     *
+     * @param screen screen to check if it is currently on top of this Navigator's back stack
+     * @return true if the Screen parameter is the top screen on this Navigator's back stack
+     */
+    public boolean isCurrentScreen(Screen screen) {
+        return !backStack.isEmpty() && currentScreen().equals(screen);
+    }
 
-  /**
-   * Navigates from the current screen back to the screen in this Navigator's back stack immediately before the
-   * Screen parameter. Screens in between the current screen and the Screen parameter on the back stack are removed.
-   * If the Screen parameter is not present in this Navigator's back stack, this method is equivalent to
-   * {@link #goBackToRoot(NavigationType) goBackToRoot(NavigationType)}
-   *
-   * @param screen  screen to navigate back to through this Navigator's back stack
-   * @param navigationType  determines how the navigation event is animated
-   */
-  public void goBackBefore(final Screen screen, NavigationType navigationType) {
-    navigate(new HistoryRewriter() {
-      @Override
-      public void rewriteHistory(Deque<Screen> history) {
-        checkArgument(history.contains(screen), "Can't go back past a screen that isn't in history.");
-        while (history.size() > 1) {
-          if (history.pop() == screen) {
-            break;
-          }
-        }
-      }
-    }, navigationType, BACKWARD);
-  }
+    /**
+     * Navigates to the Screen parameter. Animates current top screen on this Navigator's back stack out to the left and
+     * slides the Screen parameter screen in from the right. At the end of the navigation event, the Screen parameter will
+     * be the top screen on this Navigator's back stack.
+     *
+     * @param screen new top screen for this Navigator's back stack
+     */
+    public void goTo(Screen screen) {
+        navigateTo(screen, GO);
+    }
 
-  private void replace(final Screen screen, NavigationType navType) {
-    navigate(FORWARD, navType, new Runnable() {
-      @Override
-      public void run() {
-        backStack.pop();
-        backStack.push(screen);
-      }
-    });
-  }
+    /**
+     * Navigates from current screen to previous screen in this Navigator's back stack. Current screen animates out of the
+     * view by sliding out to the right and the next screen in the back stack slides in from the left.
+     *
+     * @throws IllegalStateException if this Navigator only has one screen in its back stack
+     */
+    public void goBack() {
+        checkState(!atRoot(), "Can't go back, this is the last screen. Did you mean to call handleBack() instead?");
+        navigateBack(GO);
+    }
 
-  private void navigateTo(final Screen screen, NavigationType navType) {
-    navigate(FORWARD, navType, new Runnable() {
-      @Override
-      public void run() {
-        backStack.push(screen);
-      }
-    });
-  }
+    /**
+     * Navigates from current screen all the way to the root screen in this Navigator's back stack, removing all
+     * intermediate screen in this Navigator's back stack along the way. The current screen animates out of the view
+     * according to the animation specified by the NavigationType parameter.
+     *
+     * @param navigationType determines how the navigation event is animated
+     */
+    public void goBackToRoot(NavigationType navigationType) {
+        navigate(new HistoryRewriter() {
+            @Override
+            public void rewriteHistory(Deque<Screen> history) {
+                while (history.size() > 1) {
+                    history.pop();
+                }
+            }
+        }, navigationType, BACKWARD);
+    }
 
-  private void navigateBack(NavigationType navType) {
-    navigate(BACKWARD, navType, new Runnable() {
-      @Override
-      public void run() {
-        backStack.pop();
-      }
-    });
-  }
+    /**
+     * Navigates from the current screen back to the Screen parameter wherever it is in this Navigator's back stack.
+     * Screens in between the current screen and the Screen parameter on the back stack are removed. If the Screen
+     * parameter is not present in this Navigator's back stack, this method is equivalent to
+     * {@link #goBackToRoot(NavigationType) goBackToRoot(NavigationType.GO)}
+     *
+     * @param screen screen to navigate back to through this Navigator's back stack
+     */
+    public void goBackTo(final Screen screen) {
+        goBackTo(screen, GO);
+    }
 
-  private void navigate(final Direction direction, final NavigationType navType, final Runnable backStackOperation) {
-    container.setInterceptTouchEvents(true);
-    checkNotNull(activity, "The activity cannot be null. Did you forget to call onCreate()?");
-    currentScreen().onPause(activity);
-    View from = hideCurrentScreen();
-    backStackOperation.run();
-    View to = showCurrentScreen(direction);
-    currentScreen().onResume(activity);
-    animateAndRemove(from, to, navType, direction);
-    reportEvent(navType, direction);
-  }
+    /**
+     * Navigates from the current screen back to the Screen parameter wherever it is in this Navigator's back stack.
+     * Screens in between the current screen and the Screen parameter on the back stack are removed. If the Screen
+     * parameter is not present in this Navigator's back stack, this method is equivalent to
+     * {@link #goBackToRoot(NavigationType) goBackToRoot(navigationType)}
+     *
+     * @param screen         screen to navigate back to through this Navigator's back stack
+     * @param navigationType determines how the navigation event is animated
+     */
+    public void goBackTo(final Screen screen, NavigationType navigationType) {
+        navigate(new HistoryRewriter() {
+            @Override
+            public void rewriteHistory(Deque<Screen> history) {
+                checkArgument(history.contains(screen), "Can't go back to a screen that isn't in history.");
+                while (history.size() > 1) {
+                    if (history.peek() == screen) {
+                        break;
+                    }
+                    history.pop();
+                }
+            }
+        }, navigationType, BACKWARD);
+    }
 
-  private void animateAndRemove(final View from, final View to, final NavigationType navType, final Direction direction) {
+    /**
+     * Navigates from the current screen back to the screen in this Navigator's back stack immediately before the
+     * Screen parameter. Screens in between the current screen and the Screen parameter on the back stack are removed.
+     * If the Screen parameter is not present in this Navigator's back stack, this method is equivalent to
+     * {@link #goBackToRoot(NavigationType) goBackToRoot(NavigationType.GO)}
+     *
+     * @param screen screen to navigate back to through this Navigator's back stack
+     */
+    public void goBackBefore(Screen screen) {
+        goBackBefore(screen, GO);
+    }
+
+    /**
+     * Navigates from the current screen back to the screen in this Navigator's back stack immediately before the
+     * Screen parameter. Screens in between the current screen and the Screen parameter on the back stack are removed.
+     * If the Screen parameter is not present in this Navigator's back stack, this method is equivalent to
+     * {@link #goBackToRoot(NavigationType) goBackToRoot(NavigationType)}
+     *
+     * @param screen         screen to navigate back to through this Navigator's back stack
+     * @param navigationType determines how the navigation event is animated
+     */
+    public void goBackBefore(final Screen screen, NavigationType navigationType) {
+        navigate(new HistoryRewriter() {
+            @Override
+            public void rewriteHistory(Deque<Screen> history) {
+                checkArgument(history.contains(screen), "Can't go back past a screen that isn't in history.");
+                while (history.size() > 1) {
+                    if (history.pop() == screen) {
+                        break;
+                    }
+                }
+            }
+        }, navigationType, BACKWARD);
+    }
+
+    private void replace(final Screen screen, NavigationType navType) {
+        navigate(FORWARD, navType, new Runnable() {
+            @Override
+            public void run() {
+                backStack.pop();
+                backStack.push(screen);
+            }
+        });
+    }
+
+    private void navigateTo(final Screen screen, NavigationType navType) {
+        navigate(FORWARD, navType, new Runnable() {
+            @Override
+            public void run() {
+                backStack.push(screen);
+            }
+        });
+    }
+
+    private void navigateBack(NavigationType navType) {
+        navigate(BACKWARD, navType, new Runnable() {
+            @Override
+            public void run() {
+                backStack.pop();
+            }
+        });
+    }
+
+    private void navigate(final Direction direction, final NavigationType navType, final Runnable backStackOperation) {
+        container.setInterceptTouchEvents(true);
+        checkNotNull(activity, "The activity cannot be null. Did you forget to call onCreate()?");
+        currentScreen().onPause(activity.getContext());
+        View from = hideCurrentScreen();
+        backStackOperation.run();
+        View to = showCurrentScreen(direction);
+        currentScreen().onResume(activity.getContext());
+        animateAndRemove(from, to, navType, direction);
+        reportEvent(navType, direction);
+    }
+
+  private void animateAndRemove(
+      final View from, final View to, final NavigationType navType, final Direction direction) {
     ghostView = from;
     final Transition transitionToUse = overridingTransition != null ? overridingTransition : transition;
     overridingTransition = null;
     whenMeasured(to, new Views.OnMeasured() {
       @Override
       public void onMeasured() {
-        currentScreen().transitionStarted();
-        transitionToUse.animate(from, to, navType, direction, new Transition.Callback() {
+        currentScreen().transitionStarted();transitionToUse.animate(from, to, navType, direction, new Transition.Callback() {
           @Override
           public void onAnimationEnd() {
             if (container != null) {
@@ -561,8 +561,7 @@ public class Navigator implements BackHandler {
               if (from == ghostView) {
                 // Only clear the ghost if it's the same as the view we just removed
                 ghostView = null;
-              }
-              currentScreen().transitionFinished();
+              }currentScreen().transitionFinished();
               container.setInterceptTouchEvents(false);
             }
           }
@@ -571,163 +570,163 @@ public class Navigator implements BackHandler {
     });
   }
 
-  private boolean isAnimating() {
-    return ghostView != null;
-  }
-
-  private View showCurrentScreen(Direction direction) {
-    Screen currentScreen = currentScreen();
-    View view = currentScreen.recreateView(activity, this);
-    container.addView(view, direction == FORWARD ? container.getChildCount() : 0);
-    currentScreen.createDialog();
-    activity.setTitle(currentScreen.getTitle(activity));
-    currentScreen.onShow(activity);
-    for (ScreenLifecycleListener lifecycleListener : lifecycleListeners) {
-      lifecycleListener.onShow(currentScreen);
-    }
-    callOnNavigate(currentScreen);
-    // Need to post to avoid animation bug on disappearing menu
-    new Handler(getMainLooper()).post(new Runnable() {
-      @Override
-      public void run() {
-        updateMenu();
-      }
-    });
-    return view;
-  }
-
-  private View hideCurrentScreen() {
-    // if we were already animating a view, just skip it and remove the view immediately
-    if (isAnimating()) {
-      container.removeView(ghostView);
-      ghostView = null;
-    }
-    checkState(container.getChildCount() == 1, "The container view must have a single child, but it had " + container.getChildCount());
-
-    Screen currentScreen = currentScreen();
-    for (ScreenLifecycleListener lifecycleListener : lifecycleListeners) {
-      lifecycleListener.onHide(currentScreen);
-    }
-    currentScreen.onHide(activity);
-    currentScreen.destroyDialog();
-    currentScreen.destroyView();
-    View view = container.getChildAt(0); // will be removed at the end of the animation
-    return view;
-  }
-
-  private void callOnNavigate(Screen currentScreen) {
-    if (activity instanceof NavigationListener) {
-      ((NavigationListener) activity).onNavigate(
-          ActionBarConfig.with()
-              .visible(currentScreen.shouldShowActionBar())
-              .animated(currentScreen.shouldAnimateActionBar())
-              .colorRes(currentScreen.getActionBarColorRes())
-              .build());
-    }
-  }
-
-  private void updateMenu() {
-    if (menu != null) {
-      for (int i = 0; i < menu.size(); i++) {
-        menu.getItem(i).setVisible(false);
-      }
-      currentScreen().onUpdateMenu(menu);
-    }
-  }
-
-  private boolean sameActivity(Activity activity) {
-    return this.activity == activity;
-  }
-
-  private void checkOnCreateNotYetCalled(Activity activity, String reason) {
-    checkState(this.activity == null || !sameActivity(activity), reason);
-  }
-
-  private void checkBackStackNotEmpty() {
-    checkState(!backStack.isEmpty(), "There must be a least one screen in the backstack");
-  }
-
-  private void reportEvent(NavigationType navType, Direction direction) {
-    Event event = new Event(navType, direction, getBackStackDescription());
-    eventTracker.reportEvent(event);
-    if (loggingEnabled) {
-      Log.d(Navigator.class.getSimpleName(), event.toString());
-    }
-  }
-
-  /**
-   * Returns a human-readable string describing the screens in this Navigator's back stack.
-   *
-   * @return a human-readable description of the back stack.
-   */
-  public String getBackStackDescription() {
-    ArrayList<Screen> backStackCopy = new ArrayList<>(backStack);
-    Collections.reverse(backStackCopy);
-    String currentScreen = "";
-    if (!backStackCopy.isEmpty()) {
-      currentScreen = backStackCopy.remove(backStackCopy.size() - 1).toString();
-    }
-    return TextUtils.join(" > ", backStackCopy) + (backStackCopy.isEmpty() ? "" : " > ") + "[" + currentScreen + "]";
-  }
-
-  /**
-   * Returns a human-readable string describing the navigation events that happened recently
-   * (including the state of the backStack at the time).
-   * How many events are kept can be configured using {@link Builder#maxEventsTracked(int)} (the default is 50).
-   *
-   * @return a human-readable description of the past events.
-   */
-  public String getEventsDescription() {
-    return eventTracker.getEventsDescription();
-  }
-
-  /**
-   * Sets a specific transition to use during the next navigation event. The overriding transition will only be used
-   * once, subsequent navigation events will use the default transition specified during construction of this Navigator.
-   *
-   * @param overridingTransition  transition to override default
-   * @return this Navigator that will use the Transition param for its next navigation event
-   */
-  public Navigator overrideTransition(Transition overridingTransition) {
-    this.overridingTransition = overridingTransition;
-    return this;
-  }
-
-  /**
-   * Builder for constructing Navigators with particular parameters.
-   *
-   * Use {@link #withRoot(Screen)} to create a Builder, which can then be used to construct a navigator.
-   */
-  public static class Builder {
-
-    private final Screen root;
-    private Transition transition = new DefaultTransition();
-    private boolean loggingEnabled;
-    private int maxEventsTracked = 50;
-
-    Builder(Screen root) {
-      this.root = root;
+    private boolean isAnimating() {
+        return ghostView != null;
     }
 
-    public Builder transition(Transition transition) {
-      this.transition = transition;
-      return this;
+    private View showCurrentScreen(Direction direction) {
+        Screen currentScreen = currentScreen();
+        View view = currentScreen.recreateView(activity, this);
+        container.addView(view, direction == FORWARD ? container.getChildCount() : 0);
+        currentScreen.createDialog();
+        activity.setTitle(currentScreen.getTitle(activity.getContext()));
+        currentScreen.onShow(activity.getContext());
+        for (ScreenLifecycleListener lifecycleListener : lifecycleListeners) {
+            lifecycleListener.onShow(currentScreen);
+        }
+        callOnNavigate(currentScreen);
+        // Need to post to avoid animation bug on disappearing menu
+        new Handler(getMainLooper()).post(new Runnable() {
+            @Override
+            public void run() {
+                updateMenu();
+            }
+        });
+        return view;
     }
 
-    public Builder loggingEnabled(boolean loggingEnabled) {
-      this.loggingEnabled = loggingEnabled;
-      return this;
+    private View hideCurrentScreen() {
+        // if we were already animating a view, just skip it and remove the view immediately
+        if (isAnimating()) {
+            container.removeView(ghostView);
+            ghostView = null;
+        }
+        checkState(container.getChildCount() == 1, "The container view must have a single child, but it had " + container.getChildCount());
+
+        Screen currentScreen = currentScreen();
+        for (ScreenLifecycleListener lifecycleListener : lifecycleListeners) {
+            lifecycleListener.onHide(currentScreen);
+        }
+        currentScreen.onHide(activity.getContext());
+        currentScreen.destroyDialog();
+        currentScreen.destroyView();
+        View view = container.getChildAt(0); // will be removed at the end of the animation
+        return view;
     }
 
-    public Builder maxEventsTracked(int maxEventsTracked) {
-      this.maxEventsTracked = maxEventsTracked;
-      return this;
+    private void callOnNavigate(Screen currentScreen) {
+        if (activity instanceof NavigationListener) {
+            ((NavigationListener) activity).onNavigate(
+                    ActionBarConfig.with()
+                            .visible(currentScreen.shouldShowActionBar())
+                            .animated(currentScreen.shouldAnimateActionBar())
+                            .colorRes(currentScreen.getActionBarColorRes())
+                            .build());
+        }
     }
 
-    public Navigator build() {
-      return new Navigator(this);
+    private void updateMenu() {
+        if (menu != null) {
+            for (int i = 0; i < menu.size(); i++) {
+                menu.getItem(i).setVisible(false);
+            }
+            currentScreen().onUpdateMenu(menu);
+        }
     }
 
-  }
+    private boolean sameActivity(ScreenAwareActivity activity) {
+        return this.activity == activity;
+    }
+
+    private void checkOnCreateNotYetCalled(ScreenAwareActivity activity, String reason) {
+        checkState(this.activity == null || !sameActivity(activity), reason);
+    }
+
+    private void checkBackStackNotEmpty() {
+        checkState(!backStack.isEmpty(), "There must be a least one screen in the backstack");
+    }
+
+    private void reportEvent(NavigationType navType, Direction direction) {
+        Event event = new Event(navType, direction, getBackStackDescription());
+        eventTracker.reportEvent(event);
+        if (loggingEnabled) {
+            Log.d(Navigator.class.getSimpleName(), event.toString());
+        }
+    }
+
+    /**
+     * Returns a human-readable string describing the screens in this Navigator's back stack.
+     *
+     * @return a human-readable description of the back stack.
+     */
+    public String getBackStackDescription() {
+        ArrayList<Screen> backStackCopy = new ArrayList<>(backStack);
+        Collections.reverse(backStackCopy);
+        String currentScreen = "";
+        if (!backStackCopy.isEmpty()) {
+            currentScreen = backStackCopy.remove(backStackCopy.size() - 1).toString();
+        }
+        return TextUtils.join(" > ", backStackCopy) + (backStackCopy.isEmpty() ? "" : " > ") + "[" + currentScreen + "]";
+    }
+
+    /**
+     * Returns a human-readable string describing the navigation events that happened recently
+     * (including the state of the backStack at the time).
+     * How many events are kept can be configured using {@link Builder#maxEventsTracked(int)} (the default is 50).
+     *
+     * @return a human-readable description of the past events.
+     */
+    public String getEventsDescription() {
+        return eventTracker.getEventsDescription();
+    }
+
+    /**
+     * Sets a specific transition to use during the next navigation event. The overriding transition will only be used
+     * once, subsequent navigation events will use the default transition specified during construction of this Navigator.
+     *
+     * @param overridingTransition transition to override default
+     * @return this Navigator that will use the Transition param for its next navigation event
+     */
+    public Navigator overrideTransition(Transition overridingTransition) {
+        this.overridingTransition = overridingTransition;
+        return this;
+    }
+
+    /**
+     * Builder for constructing Navigators with particular parameters.
+     * <p>
+     * Use {@link #withRoot(Screen)} to create a Builder, which can then be used to construct a navigator.
+     */
+    public static class Builder {
+
+        private final Screen root;
+        private Transition transition = new DefaultTransition();
+        private boolean loggingEnabled;
+        private int maxEventsTracked = 50;
+
+        Builder(Screen root) {
+            this.root = root;
+        }
+
+        public Builder transition(Transition transition) {
+            this.transition = transition;
+            return this;
+        }
+
+        public Builder loggingEnabled(boolean loggingEnabled) {
+            this.loggingEnabled = loggingEnabled;
+            return this;
+        }
+
+        public Builder maxEventsTracked(int maxEventsTracked) {
+            this.maxEventsTracked = maxEventsTracked;
+            return this;
+        }
+
+        public Navigator build() {
+            return new Navigator(this);
+        }
+
+    }
 
 }

--- a/magellan-library/src/main/java/com/wealthfront/magellan/Screen.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/Screen.java
@@ -1,6 +1,5 @@
 package com.wealthfront.magellan;
 
-import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
 import android.os.Bundle;
@@ -8,6 +7,7 @@ import android.os.Parcelable;
 import android.support.annotation.ColorRes;
 import android.support.annotation.StringRes;
 import android.support.annotation.VisibleForTesting;
+import android.util.Log;
 import android.util.SparseArray;
 import android.view.Menu;
 import android.view.ViewGroup;
@@ -39,100 +39,106 @@ import static com.wealthfront.magellan.Preconditions.checkState;
  */
 public abstract class Screen<V extends ViewGroup & ScreenView> implements BackHandler {
 
-  public static final int DEFAULT_ACTION_BAR_COLOR_RES = 0;
-  private static final String VIEW_STATE = "com.wealthfront.navigation.Screen.viewState";
+    public static final int DEFAULT_ACTION_BAR_COLOR_RES = 0;
+    private static final String VIEW_STATE = "com.wealthfront.navigation.Screen.viewState";
 
-  private Activity activity;
-  private Navigator navigator;
-  private V view;
-  private DialogCreator dialogCreator;
-  private boolean dialogIsShowing;
-  private Dialog dialog;
-  private SparseArray<Parcelable> viewState;
+    private ScreenAwareActivity activity;
+    private Navigator navigator;
+    private V view;
+    private DialogCreator dialogCreator;
+    private boolean dialogIsShowing;
+    private Dialog dialog;
+    private SparseArray<Parcelable> viewState;
   private boolean isTransitioning;
   private Queue<TransitionFinishedListener> transitionFinishedListeners = new LinkedList<>();
 
-  /**
-   * @return the View associated with this Screen or null if we are not in between {@link #onShow(Context)} and\
-   * {@link #onHide(Context)}.
-   */
-  public final V getView() {
-    return view;
-  }
-
-  /**
-   * @return the Activity associated with this Screen or null if we are not in between {@link #onShow(Context)} and\
-   * {@link #onHide(Context)}.
-   */
-  public final Activity getActivity() {
-    return activity;
-  }
-
-  /**
-   * @return the Navigator associated with this Screen.
-   */
-  public final Navigator getNavigator() {
-    return navigator;
-  }
-
-  public final Dialog getDialog() {
-    return dialog;
-  }
-
-  final void restore(Bundle savedInstanceState) {
-    if (viewState == null && savedInstanceState != null) {
-      viewState = savedInstanceState.getSparseParcelableArray(VIEW_STATE + hashCode());
+    /**
+     * @return the View associated with this Screen or null if we are not in between {@link #onShow(Context)} and\
+     * {@link #onHide(Context)}.
+     */
+    public final V getView() {
+        return view;
     }
-  }
 
-  final V recreateView(Activity activity, Navigator navigator) {
-    this.activity = activity;
-    this.navigator = navigator;
-    view = createView(activity);
-    // noinspection unchecked
-    view.setScreen(this);
-    if (viewState != null) {
-      view.restoreHierarchyState(viewState);
+    /**
+     * @return the Activity associated with this Screen or null if we are not in between {@link #onShow(Context)} and\
+     * {@link #onHide(Context)}.
+     */
+    public final ScreenAwareActivity getActivity() {
+        return activity;
     }
-    return view;
-  }
 
-  final void save(Bundle outState) {
-    saveViewState();
-    if (viewState != null) {
-      outState.putSparseParcelableArray(VIEW_STATE + hashCode(), viewState);
+    /**
+     * @return the Navigator associated with this Screen.
+     */
+    public final Navigator getNavigator() {
+        return navigator;
     }
-    viewState = null;
-  }
 
-  final void destroyView() {
-    saveViewState();
-    activity = null;
-    view = null;
-  }
-
-  private void saveViewState() {
-    if (view != null) {
-      viewState = new SparseArray<>();
-      view.saveHierarchyState(viewState);
+    public final Dialog getDialog() {
+        return dialog;
     }
-  }
 
-  final void createDialog() {
-    if (dialogCreator != null && dialogIsShowing) {
-      dialog = dialogCreator.createDialog(activity);
-      dialog.show();
+    final void restore(Bundle savedInstanceState) {
+        if (viewState == null && savedInstanceState != null) {
+            viewState = savedInstanceState.getSparseParcelableArray(VIEW_STATE + hashCode());
+        }
     }
-  }
 
-  final void destroyDialog() {
-    if (dialog != null) {
-      dialogIsShowing = dialog.isShowing();
-      dialog.setOnDismissListener(null);
-      dialog.dismiss();
-      dialog = null;
+    final V recreateView(ScreenAwareActivity activity, Navigator navigator) {
+        this.activity = activity;
+        this.navigator = navigator;
+        if(activity == null){
+            view = createView(null);
+        } else {
+            view = createView(activity.getContext());
+        }
+
+        // noinspection unchecked
+        view.setScreen(this);
+        if (viewState != null) {
+            view.restoreHierarchyState(viewState);
+        }
+        return view;
     }
-  }
+
+    final void save(Bundle outState) {
+        saveViewState();
+        if (viewState != null) {
+            outState.putSparseParcelableArray(VIEW_STATE + hashCode(), viewState);
+        }
+        viewState = null;
+    }
+
+    final void destroyView() {
+        saveViewState();
+        activity = null;
+        view = null;
+    }
+
+    private void saveViewState() {
+        if (view != null) {
+            viewState = new SparseArray<>();
+            view.saveHierarchyState(viewState);
+        }
+    }
+
+    @Deprecated
+    final void createDialog() {
+//    if (dialogCreator != null && dialogIsShowing) {
+//      dialog = dialogCreator.createDialog(carActivity);
+//      dialog.show();
+//    }
+    }
+
+    final void destroyDialog() {
+        if (dialog != null) {
+            dialogIsShowing = dialog.isShowing();
+            dialog.setOnDismissListener(null);
+            dialog.dismiss();
+            dialog = null;
+        }
+    }
 
   void transitionStarted() {
     isTransitioning = true;
@@ -157,134 +163,139 @@ public abstract class Screen<V extends ViewGroup & ScreenView> implements BackHa
     } else {
       listener.onTransitionFinished();
     }
-  }
-
-  /**
+  }/**
    * @return true if we should show the ActionBar, false otherwise (true by default).
    */
   protected boolean shouldShowActionBar() {
     return true;
   }
 
-  /**
-   * @return true if we should animate the ActionBar, false otherwise (true by default).
-   */
-  protected boolean shouldAnimateActionBar() {
-    return true;
-  }
-
-  public String getTitle(Context context) {
-    return "";
-  }
-
-  /**
-   * @return the color of the ActionBar (invalid by default).
-   */
-  @ColorRes
-  protected int getActionBarColorRes() {
-    return DEFAULT_ACTION_BAR_COLOR_RES;
-  }
-
-  protected void onRestore(Bundle savedInstanceState) {}
-
-  /**
-   * The only mandatory method to implement in a Screen. <b>Must</b> create and return a new instance of the View
-   * to be displayed for this Screen.
-   */
-  protected abstract V createView(Context context);
-
-  /**
-   * Override this method to dynamically change the menu.
-   */
-  protected void onUpdateMenu(Menu menu) {}
-
-  /**
-   * Called when the Activity is resumed and when the Screen is shown.
-   */
-  protected void onResume(Context context) {}
-
-  /**
-   * Called when the Screen in shown (including on rotation).
-   */
-  protected void onShow(Context context) {}
-
-  protected void onSave(Bundle outState) {}
-
-  /**
-   * Called when the Activity is paused and when the Screen is hidden.
-   */
-  protected void onPause(Context context) {}
-
-  /**
-   * Called when the Screen is hidden (including on rotation).
-   */
-  protected void onHide(Context context) {}
-
-  /**
-   * Finish the Activity, and therefore quit the app in a Single Activity Architecture.
-   */
-  protected final boolean quit() {
-    if (getActivity() != null) {
-      getActivity().finish();
+    /**
+     * @return true if we should animate the ActionBar, false otherwise (true by default).
+     */
+    protected boolean shouldAnimateActionBar() {
+        return true;
     }
-    return true;
-  }
 
-  protected final void setTitle(@StringRes int titleResId) {
-    activity.setTitle(titleResId);
-  }
+    public String getTitle(Context context) {
+        return "";
+    }
 
-  protected final void setTitle(CharSequence title) {
-    activity.setTitle(title);
-  }
+    /**
+     * @return the color of the ActionBar (invalid by default).
+     */
+    @ColorRes
+    protected int getActionBarColorRes() {
+        return DEFAULT_ACTION_BAR_COLOR_RES;
+    }
 
-  /**
-   * Display a {@link Dialog} using a {@link DialogCreator}. The dialog will be automatically recreated and redisplayed
-   * on rotation.
-   */
-  protected final void showDialog(DialogCreator dialogCreator) {
-    this.dialogCreator = dialogCreator;
-    this.dialogIsShowing = true;
-    createDialog();
-  }
+    protected void onRestore(Bundle savedInstanceState) {
+    }
 
-  /**
-   * Override this method to implement a custom behavior one back pressed.
-   *
-   * @return true if the method consumed the back event, false otherwise.
-   */
-  @Override
-  public boolean handleBack() {
-    return false;
-  }
+    /**
+     * The only mandatory method to implement in a Screen. <b>Must</b> create and return a new instance of the View
+     * to be displayed for this Screen.
+     */
+    protected abstract V createView(Context context);
 
-  /**
-   * @return a String representation of the Screen to be used for logging purposes. Return the Simple name of the class
-   * by default.
-   */
-  @Override
-  public String toString() {
-    return getClass().getSimpleName();
-  }
+    /**
+     * Override this method to dynamically change the menu.
+     */
+    protected void onUpdateMenu(Menu menu) {
+    }
 
-  @VisibleForTesting
-  public final void setView(V view) {
-    this.view = view;
-  }
+    /**
+     * Called when the Activity is resumed and when the Screen is shown.
+     */
+    protected void onResume(Context context) {
+    }
 
-  @VisibleForTesting
-  public final void setActivity(Activity activity) {
-    this.activity = activity;
-  }
+    /**
+     * Called when the Screen in shown (including on rotation).
+     */
+    protected void onShow(Context context) {
+    }
 
-  @VisibleForTesting
-  public final void setNavigator(Navigator navigator) {
-    this.navigator = navigator;
-  }
+    protected void onSave(Bundle outState) {
+    }
 
-  protected final void checkOnCreateNotYetCalled(String reason) {
-    checkState(activity == null, reason);
-  }
+    /**
+     * Called when the Activity is pauseZOxld and when the Screen is hidden.
+     */
+    protected void onPause(Context context) {
+    }
+
+    /**
+     * Called when the Screen is hidden (including on rotation).
+     */
+    protected void onHide(Context context) {
+    }
+
+    /**
+     * Finish the Activity, and therefore quit the app in a Single Activity Architecture.
+     */
+    protected final boolean quit() {
+        if (getActivity() != null) {
+            getActivity().onDestroy();
+        }
+        return true;
+    }
+
+    protected final void setTitle(@StringRes int titleResId) {
+        activity.setTitle(titleResId);
+    }
+
+    protected final void setTitle(CharSequence title) {
+        activity.setTitle(title);
+    }
+
+    /**
+     * Display a {@link Dialog} using a {@link DialogCreator}. The dialog will be automatically recreated and redisplayed
+     * on rotation.
+     */
+    protected final void showDialog(DialogCreator dialogCreator) {
+        this.dialogCreator = dialogCreator;
+        this.dialogIsShowing = true;
+        createDialog();
+    }
+
+    /**
+     * Override this method to implement a custom behavior one back pressed.
+     *
+     * @return true if the method consumed the back event, false otherwise.
+     */
+    @Override
+    public boolean handleBack() {
+        return false;
+    }
+
+    /**
+     * @return a String representation of the Screen to be used for logging purposes. Return the Simple name of the class
+     * by default.
+     */
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+
+    @VisibleForTesting
+    public final void setView(V view) {
+        this.view = view;
+    }
+
+    @VisibleForTesting
+    public final void setActivity(ScreenAwareActivity activity) {
+        this.activity = activity;
+    }
+
+    @VisibleForTesting
+    public final void setNavigator(Navigator navigator) {
+        this.navigator = navigator;
+    }
+
+    protected final void checkOnCreateNotYetCalled(String reason) {
+        checkState(activity == null, reason);
+    }
 
   /**
    * A simple interface with a method to be run when the screen's transition is finished.

--- a/magellan-library/src/main/java/com/wealthfront/magellan/ScreenAwareActivity.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/ScreenAwareActivity.java
@@ -1,0 +1,17 @@
+package com.wealthfront.magellan;
+
+import android.content.Context;
+import android.view.View;
+
+public interface ScreenAwareActivity {
+
+    Context getContext();
+
+    void onDestroy();
+
+    void setTitle(int titleResId);
+
+    void setTitle(CharSequence title);
+
+    View findViewById(int id);
+}

--- a/magellan-library/src/test/java/com/wealthfront/magellan/NavigatorTest.java
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/NavigatorTest.java
@@ -1,6 +1,7 @@
 package com.wealthfront.magellan;
 
 import android.app.Activity;
+import android.content.Context;
 import android.os.Bundle;
 import android.view.View;
 
@@ -36,469 +37,492 @@ import static org.robolectric.RuntimeEnvironment.application;
 @RunWith(RobolectricTestRunner.class)
 public class NavigatorTest {
 
-  @Mock Screen root;
-  @Mock Screen screen;
-  @Mock Screen screen2;
-  @Mock Screen screen3;
-  @Mock ScreenLifecycleListener lifecycleListener;
-  NavigatorActivity activity;
-  Navigator navigator;
-  ScreenContainer container;
-
-  @Before
-  public void setUp() {
-    initMocks(this);
-
-    navigator = Navigator.withRoot(root)
-        .transition(new NoAnimationTransition())
-        .maxEventsTracked(2)
-        .build();
-
-    activity = spy(setupActivity(NavigatorActivity.class));
-    container = new ScreenContainer(application);
-    container.setId(R.id.magellan_container);
-    activity.setContentView(container);
-
-    when(root.createView(activity)).thenAnswer(
-        new Answer<View>() {
-          @Override
-          public View answer(InvocationOnMock invocation) throws Throwable {
-            return new BaseScreenView(application);
-          }
-        });
-    when(screen.createView(activity)).thenReturn(new BaseScreenView(application));
-    when(screen2.createView(activity)).thenReturn(new BaseScreenView(application));
-    when(screen3.createView(activity)).thenReturn(new BaseScreenView(application));
-  }
-
-  @Test
-  public void onCreateOnSaveOnDestroy() {
-    navigator.onCreate(activity, null);
-    verify(root).onRestore(null);
-    verify(root).createView(activity);
-    verify(root).onShow(activity);
-
-    Bundle state = new Bundle();
-    navigator.onSaveInstanceState(state);
-    verify(root).onSave(state);
-
-    navigator.onDestroy(activity);
-    verify(root).onHide(activity);
-  }
-
-  @Test
-  public void onCreateOptionsMenu() {
-    RoboMenu menu = new RoboMenu();
-    menu.add("item0");
-    menu.add("item1");
-
-    navigator.onCreateOptionsMenu(menu);
-
-    assertThat(menu.getItem(0).isVisible()).isFalse();
-    assertThat(menu.getItem(1).isVisible()).isFalse();
-    verify(root).onUpdateMenu(menu);
-  }
-
-  @Test
-  public void onPrepareOptionsMenu() {
-    RoboMenu menu = new RoboMenu();
-    menu.add("item0");
-    menu.add("item1");
-
-    navigator.onPrepareOptionsMenu(menu);
-
-    assertThat(menu.getItem(0).isVisible()).isFalse();
-    assertThat(menu.getItem(1).isVisible()).isFalse();
-    verify(root).onUpdateMenu(menu);
-  }
-
-  @Test
-  public void onResume() {
-    navigator.onCreate(activity, null);
-    reset(root);
-    navigator.onResume(activity);
-
-    verify(root).onResume(activity);
-  }
-
-  @Test
-  public void onPause() {
-    navigator.onCreate(activity, null);
-    navigator.onPause(activity);
-
-    verify(root).onPause(activity);
-  }
-
-  @Test
-  public void onResume_differentActivity() {
-    navigator.onCreate(activity, null);
-    reset(root);
-    verifyNoMoreInteractions(root);
-    navigator.onResume(new Activity());
-  }
-
-  @Test
-  public void onPause_differentActivity() {
-    navigator.onCreate(activity, null);
-    reset(root);
-    verifyNoMoreInteractions(root);
-    navigator.onPause(new Activity());
-  }
-
-  @Test
-  public void lifecycleListener() {
-    navigator.addLifecycleListener(lifecycleListener);
-    navigator.onCreate(activity, null);
-
-    navigator.goTo(screen);
-    navigator.goBack();
-
-    verify(lifecycleListener, times(2)).onShow(root);
-    verify(lifecycleListener).onShow(screen);
-    verify(lifecycleListener).onHide(root);
-    verify(lifecycleListener).onHide(screen);
-
-    navigator.removeLifecycleListener(lifecycleListener);
-    navigator.goTo(screen);
-    navigator.goBack();
-
-    verifyNoMoreInteractions(lifecycleListener);
-  }
-
-  @Test
-  public void handleBack() {
-    navigator.onCreate(activity, null);
-    navigator.goTo(screen);
-
-    assertThat(navigator.currentScreen()).isEqualTo(screen);
-    boolean handled = navigator.handleBack();
-    assertThat(handled).isTrue();
-    assertThat(navigator.currentScreen()).isEqualTo(root);
-
-    handled = navigator.handleBack();
-    assertThat(handled).isFalse();
-  }
-
-  @Test
-  public void showHide() {
-    RoboMenu menu = new RoboMenu();
-    navigator.onCreate(activity, null);
-    navigator.onCreateOptionsMenu(menu);
-    navigator.show(screen);
-
-    verify(root).onHide(activity);
-    verify(activity, times(2)).onNavigate(isA(ActionBarConfig.class));
-    assertThat(navigator.currentScreen()).isEqualTo(screen);
-    reset(activity);
-
-    navigator.hide(screen);
-
-    assertThat(navigator.currentScreen()).isEqualTo(root);
-    verify(screen).onHide(activity);
-    verify(root, times(2)).onShow(activity);
-    verify(activity).onNavigate(isA(ActionBarConfig.class));
-  }
-
-  @Test
-  public void goBack() {
-    navigator.onCreate(activity, null);
-    navigator.goTo(screen);
-
-    verify(root).onHide(activity);
-    verify(screen).onShow(activity);
-    assertThat(navigator.currentScreen()).isEqualTo(screen);
-    reset(activity);
-
-    navigator.goBack();
-
-    verify(screen).onHide(activity);
-    verify(root, times(2)).onShow(activity);
-    verify(activity).onNavigate(isA(ActionBarConfig.class));
-    assertThat(navigator.currentScreen()).isEqualTo(root);
-  }
-
-  @Test
-  public void goBackToRoot_notAtRoot() {
-    navigator.onCreate(activity, null);
-    navigator.goTo(screen);
-    navigator.goTo(screen2);
-
-    navigator.goBackToRoot(NO_ANIM);
-
-    InOrder inOrder = inOrder(root);
-    inOrder.verify(root).onHide(activity);
-    inOrder.verify(root).onShow(activity);
-    assertThat(navigator.currentScreen()).isEqualTo(root);
-  }
-
-  @Test
-  public void goBackToRoot_alreadyAtRoot() {
-    navigator.onCreate(activity, null);
-
-    navigator.goBackToRoot(NO_ANIM);
-
-    InOrder inOrder = inOrder(root);
-    inOrder.verify(root).onHide(activity);
-    inOrder.verify(root).onShow(activity);
-    assertThat(navigator.currentScreen()).isEqualTo(root);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void goBackTo_screenNotInHistory() {
-    navigator.onCreate(activity, null);
-
-    navigator.goBackTo(screen);
-  }
-
-  @Test
-  public void goBackTo() {
-    navigator.onCreate(activity, null);
-    navigator.goTo(screen);
-    navigator.goTo(screen2);
-
-    navigator.goBackTo(screen);
-
-    assertThat(navigator.currentScreen()).isEqualTo(screen);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void goBackBefore_screenNotInHistory() {
-    navigator.onCreate(activity, null);
-
-    navigator.goBackBefore(screen);
-  }
-
-  @Test
-  public void goBackBefore() {
-    navigator.onCreate(activity, null);
-    navigator.goTo(screen);
-    navigator.goTo(screen2);
-
-    navigator.goBackBefore(screen);
-
-    assertThat(navigator.currentScreen()).isEqualTo(root);
-  }
-
-  @Test
-  public void saveRestore() {
-    navigator.onCreate(activity, null);
-    navigator.goTo(screen);
-
-    Bundle state = new Bundle();
-    navigator.onSaveInstanceState(state);
-
-    verify(root).onSave(state);
-    verify(screen).onSave(state);
-
-    navigator.onDestroy(activity);
-    container.removeAllViews();
-    navigator.onCreate(activity, state);
-
-    verify(root).onRestore(state);
-    verify(screen).onRestore(state);
-  }
-
-  @Test
-  public void replace() {
-    navigator.onCreate(activity, null);
-    navigator.replace(screen);
-
-    verify(root).onHide(activity);
-    verify(screen).onShow(activity);
-    verify(activity, times(2)).onNavigate(isA(ActionBarConfig.class));
-    assertThat(navigator.currentScreen()).isEqualTo(screen);
-
-    boolean canGoBack = navigator.handleBack();
-
-    assertThat(canGoBack).isFalse();
-  }
-
-  @Test
-  public void resetWithRoot() {
-    navigator.onCreate(activity, null);
-    navigator.goTo(screen);
-
-    assertThat(navigator.currentScreen()).isEqualTo(screen);
-
-    navigator.onDestroy(activity);
-
-    navigator.resetWithRoot(activity, root);
-
-    verify(screen).onHide(activity);
-    assertThat(navigator.currentScreen()).isEqualTo(root);
-  }
-
-  @Test
-  public void resetWithRoot_differentActivity() {
-    navigator.onCreate(activity, null);
-
-    navigator.resetWithRoot(new Activity(), root);
-  }
-
-  @Test(expected = IllegalStateException.class)
-  public void resetWithRoot_afterOnCreate() {
-    navigator.onCreate(activity, null);
-
-    navigator.resetWithRoot(activity, root);
-  }
-
-  @Test
-  public void rewriteHistory() {
-    navigator.onCreate(activity, null);
-    navigator.goTo(screen);
-
-    assertThat(navigator.currentScreen()).isEqualTo(screen);
-
-    navigator.onDestroy(activity);
-
-    navigator.rewriteHistory(activity, new HistoryRewriter() {
-      @Override
-      public void rewriteHistory(Deque<Screen> history) {
-        history.pop();
-      }
-    });
-
-    assertThat(navigator.currentScreen()).isEqualTo(root);
-  }
-
-  @Test
-  public void rewriteHistory_differentActivity() {
-    navigator.onCreate(activity, null);
-
-    navigator.rewriteHistory(new Activity(), new HistoryRewriter() {
-      @Override
-      public void rewriteHistory(Deque<Screen> history) {
-      }
-    });
-  }
-
-  @Test(expected = IllegalStateException.class)
-  public void rewriteHistory_afterOnCreate() {
-    navigator.onCreate(activity, null);
-
-    navigator.rewriteHistory(activity, new HistoryRewriter() {
-      @Override
-      public void rewriteHistory(Deque<Screen> history) {
-      }
-    });
-  }
-
-  @Test
-  public void actionBarConfig() {
-    when(screen.shouldShowActionBar()).thenReturn(true);
-    when(screen.shouldAnimateActionBar()).thenReturn(true);
-    when(screen.getActionBarColorRes()).thenReturn(42);
-
-    navigator.onCreate(activity, null);
-    navigator.goTo(screen);
-
-    verify(screen).onShow(activity);
-    verify(activity, times(2)).onNavigate(isA(ActionBarConfig.class));
-    assertThat(activity.actionBarConfig.visible()).isTrue();
-    assertThat(activity.actionBarConfig.animated()).isTrue();
-    assertThat(activity.actionBarConfig.colorRes()).isEqualTo(42);
-    assertThat(navigator.currentScreen()).isEqualTo(screen);
-  }
-
-  @Test
-  public void navigate() {
-    when(screen.shouldShowActionBar()).thenReturn(false);
-    when(screen2.shouldShowActionBar()).thenReturn(true);
-
-    navigator.onCreate(activity, null);
-    navigator.goTo(screen);
-
-    navigator.navigate(new HistoryRewriter() {
-      @Override
-      public void rewriteHistory(Deque<Screen> history) {
-        history.clear();
-        history.push(root);
-        history.push(screen2);
-      }
-    });
-
-    verify(screen).onHide(activity);
-    verify(screen2).onShow(activity);
-    assertThat(navigator.currentScreen()).isEqualTo(screen2);
-  }
-
-  @Test
-  public void consumeTouchEventsDuringNavigate() {
-    Robolectric.getForegroundThreadScheduler().pause();
-    navigator.onCreate(activity, null);
-    assertThat(container.onInterceptTouchEvent(null)).isFalse();
-
-    navigator.goTo(screen);
-
-    assertThat(container.onInterceptTouchEvent(null)).isTrue();
-  }
-
-  @Test(expected = IllegalStateException.class)
-  public void goBackTooMuch() {
-    navigator.onCreate(activity, null);
-    navigator.goBack();
-    navigator.goBack();
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void onCreateNotCalled() {
-    navigator.goTo(screen);
-  }
-
-  @Test(expected = IllegalStateException.class)
-  public void noContainer() {
-    activity.findViewById(R.id.magellan_container).setId(0);
-    navigator.onCreate(activity, null);
-  }
-
-  @Test
-  public void getEventsDescription() {
-    navigator.onCreate(activity, null);
-
-    navigator.goTo(screen);
-
-    assertThat(navigator.getEventsDescription()).isEqualTo(
-        "GO FORWARD - Backstack: root > [screen]\n"
-    );
-
-    navigator.goTo(screen2);
-
-    assertThat(navigator.getEventsDescription()).isEqualTo(
-        "GO FORWARD - Backstack: root > [screen]\n" +
-        "GO FORWARD - Backstack: root > screen > [screen2]\n"
-    );
-
-    navigator.goTo(screen3);
-
-    assertThat(navigator.getEventsDescription()).isEqualTo(
-        "GO FORWARD - Backstack: root > screen > [screen2]\n" +
-        "GO FORWARD - Backstack: root > screen > screen2 > [screen3]\n"
-    );
-
-    navigator.goBack();
-
-    assertThat(navigator.getEventsDescription()).isEqualTo(
-        "GO FORWARD - Backstack: root > screen > screen2 > [screen3]\n" +
-        "GO BACKWARD - Backstack: root > screen > [screen2]\n"
-    );
-
-    navigator.show(screen3);
-
-    assertThat(navigator.getEventsDescription()).isEqualTo(
-        "GO BACKWARD - Backstack: root > screen > [screen2]\n" +
-        "SHOW FORWARD - Backstack: root > screen > screen2 > [screen3]\n"
-    );
-  }
-
-  private static class NavigatorActivity extends Activity implements NavigationListener {
-
-    ActionBarConfig actionBarConfig;
-
-    @Override
-    public void onNavigate(ActionBarConfig actionBarConfig) {
-      this.actionBarConfig = actionBarConfig;
+    @Mock
+    Screen root;
+    @Mock
+    Screen screen;
+    @Mock
+    Screen screen2;
+    @Mock
+    Screen screen3;
+    @Mock
+    ScreenLifecycleListener lifecycleListener;
+    NavigatorActivity activity;
+    Navigator navigator;
+    ScreenContainer container;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+
+        navigator = Navigator.withRoot(root)
+                .transition(new NoAnimationTransition())
+                .maxEventsTracked(2)
+                .build();
+
+        activity = spy(setupActivity(NavigatorActivity.class));
+        container = new ScreenContainer(application);
+        container.setId(R.id.magellan_container);
+        activity.setContentView(container);
+
+        when(root.createView(activity)).thenAnswer(
+                new Answer<View>() {
+                    @Override
+                    public View answer(InvocationOnMock invocation) throws Throwable {
+                        return new BaseScreenView(application);
+                    }
+                });
+        when(screen.createView(activity)).thenReturn(new BaseScreenView(application));
+        when(screen2.createView(activity)).thenReturn(new BaseScreenView(application));
+        when(screen3.createView(activity)).thenReturn(new BaseScreenView(application));
     }
 
-  }
+    @Test
+    public void onCreateOnSaveOnDestroy() {
+        navigator.onCreate(activity, null);
+        verify(root).onRestore(null);
+        verify(root).createView(activity);
+        verify(root).onShow(activity);
 
+        Bundle state = new Bundle();
+        navigator.onSaveInstanceState(state);
+        verify(root).onSave(state);
+
+        navigator.onDestroy(activity);
+        verify(root).onHide(activity);
+    }
+
+    @Test
+    public void onCreateOptionsMenu() {
+        RoboMenu menu = new RoboMenu();
+        menu.add("item0");
+        menu.add("item1");
+
+        navigator.onCreateOptionsMenu(menu);
+
+        assertThat(menu.getItem(0).isVisible()).isFalse();
+        assertThat(menu.getItem(1).isVisible()).isFalse();
+        verify(root).onUpdateMenu(menu);
+    }
+
+    @Test
+    public void onPrepareOptionsMenu() {
+        RoboMenu menu = new RoboMenu();
+        menu.add("item0");
+        menu.add("item1");
+
+        navigator.onPrepareOptionsMenu(menu);
+
+        assertThat(menu.getItem(0).isVisible()).isFalse();
+        assertThat(menu.getItem(1).isVisible()).isFalse();
+        verify(root).onUpdateMenu(menu);
+    }
+
+    @Test
+    public void onResume() {
+        navigator.onCreate(activity, null);
+        reset(root);
+        navigator.onResume(activity);
+
+        verify(root).onResume(activity);
+    }
+
+    @Test
+    public void onPause() {
+        navigator.onCreate(activity, null);
+        navigator.onPause(activity);
+
+        verify(root).onPause(activity);
+    }
+
+    @Test
+    public void onResume_differentActivity() {
+        navigator.onCreate(activity, null);
+        reset(root);
+        verifyNoMoreInteractions(root);
+        navigator.onResume(new NavigatorActivity());
+    }
+
+    @Test
+    public void onPause_differentActivity() {
+        navigator.onCreate(activity, null);
+        reset(root);
+        verifyNoMoreInteractions(root);
+        navigator.onPause(new NavigatorActivity());
+    }
+
+    @Test
+    public void lifecycleListener() {
+        navigator.addLifecycleListener(lifecycleListener);
+        navigator.onCreate(activity, null);
+
+        navigator.goTo(screen);
+        navigator.goBack();
+
+        verify(lifecycleListener, times(2)).onShow(root);
+        verify(lifecycleListener).onShow(screen);
+        verify(lifecycleListener).onHide(root);
+        verify(lifecycleListener).onHide(screen);
+
+        navigator.removeLifecycleListener(lifecycleListener);
+        navigator.goTo(screen);
+        navigator.goBack();
+
+        verifyNoMoreInteractions(lifecycleListener);
+    }
+
+    @Test
+    public void handleBack() {
+        navigator.onCreate(activity, null);
+        navigator.goTo(screen);
+
+        assertThat(navigator.currentScreen()).isEqualTo(screen);
+        boolean handled = navigator.handleBack();
+        assertThat(handled).isTrue();
+        assertThat(navigator.currentScreen()).isEqualTo(root);
+
+        handled = navigator.handleBack();
+        assertThat(handled).isFalse();
+    }
+
+    @Test
+    public void showHide() {
+        RoboMenu menu = new RoboMenu();
+        navigator.onCreate(activity, null);
+        navigator.onCreateOptionsMenu(menu);
+        navigator.show(screen);
+
+        verify(root).onHide(activity);
+        verify(activity, times(2)).onNavigate(isA(ActionBarConfig.class));
+        assertThat(navigator.currentScreen()).isEqualTo(screen);
+        reset(activity);
+
+        navigator.hide(screen);
+
+        assertThat(navigator.currentScreen()).isEqualTo(root);
+        verify(screen).onHide(activity);
+        verify(root, times(2)).onShow(activity);
+        verify(activity).onNavigate(isA(ActionBarConfig.class));
+    }
+
+    @Test
+    public void goBack() {
+        navigator.onCreate(activity, null);
+        navigator.goTo(screen);
+
+        verify(root).onHide(activity);
+        verify(screen).onShow(activity);
+        assertThat(navigator.currentScreen()).isEqualTo(screen);
+        reset(activity);
+
+        navigator.goBack();
+
+        verify(screen).onHide(activity);
+        verify(root, times(2)).onShow(activity);
+        verify(activity).onNavigate(isA(ActionBarConfig.class));
+        assertThat(navigator.currentScreen()).isEqualTo(root);
+    }
+
+    @Test
+    public void goBackToRoot_notAtRoot() {
+        navigator.onCreate(activity, null);
+        navigator.goTo(screen);
+        navigator.goTo(screen2);
+
+        navigator.goBackToRoot(NO_ANIM);
+
+        InOrder inOrder = inOrder(root);
+        inOrder.verify(root).onHide(activity);
+        inOrder.verify(root).onShow(activity);
+        assertThat(navigator.currentScreen()).isEqualTo(root);
+    }
+
+    @Test
+    public void goBackToRoot_alreadyAtRoot() {
+        navigator.onCreate(activity, null);
+
+        navigator.goBackToRoot(NO_ANIM);
+
+        InOrder inOrder = inOrder(root);
+        inOrder.verify(root).onHide(activity);
+        inOrder.verify(root).onShow(activity);
+        assertThat(navigator.currentScreen()).isEqualTo(root);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void goBackTo_screenNotInHistory() {
+        navigator.onCreate(activity, null);
+
+        navigator.goBackTo(screen);
+    }
+
+    @Test
+    public void goBackTo() {
+        navigator.onCreate(activity, null);
+        navigator.goTo(screen);
+        navigator.goTo(screen2);
+
+        navigator.goBackTo(screen);
+
+        assertThat(navigator.currentScreen()).isEqualTo(screen);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void goBackBefore_screenNotInHistory() {
+        navigator.onCreate(activity, null);
+
+        navigator.goBackBefore(screen);
+    }
+
+    @Test
+    public void goBackBefore() {
+        navigator.onCreate(activity, null);
+        navigator.goTo(screen);
+        navigator.goTo(screen2);
+
+        navigator.goBackBefore(screen);
+
+        assertThat(navigator.currentScreen()).isEqualTo(root);
+    }
+
+    @Test
+    public void saveRestore() {
+        navigator.onCreate(activity, null);
+        navigator.goTo(screen);
+
+        Bundle state = new Bundle();
+        navigator.onSaveInstanceState(state);
+
+        verify(root).onSave(state);
+        verify(screen).onSave(state);
+
+        navigator.onDestroy(activity);
+        container.removeAllViews();
+        navigator.onCreate(activity, state);
+
+        verify(root).onRestore(state);
+        verify(screen).onRestore(state);
+    }
+
+    @Test
+    public void replace() {
+        navigator.onCreate(activity, null);
+        navigator.replace(screen);
+
+        verify(root).onHide(activity);
+        verify(screen).onShow(activity);
+        verify(activity, times(2)).onNavigate(isA(ActionBarConfig.class));
+        assertThat(navigator.currentScreen()).isEqualTo(screen);
+
+        boolean canGoBack = navigator.handleBack();
+
+        assertThat(canGoBack).isFalse();
+    }
+
+    @Test
+    public void resetWithRoot() {
+        navigator.onCreate(activity, null);
+        navigator.goTo(screen);
+
+        assertThat(navigator.currentScreen()).isEqualTo(screen);
+
+        navigator.onDestroy(activity);
+
+        navigator.resetWithRoot(activity, root);
+
+        verify(screen).onHide(activity);
+        assertThat(navigator.currentScreen()).isEqualTo(root);
+    }
+
+    @Test
+    public void resetWithRoot_differentActivity() {
+        navigator.onCreate(activity, null);
+
+        navigator.resetWithRoot(new NavigatorActivity(), root);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void resetWithRoot_afterOnCreate() {
+        navigator.onCreate(activity, null);
+
+        navigator.resetWithRoot(activity, root);
+    }
+
+    @Test
+    public void rewriteHistory() {
+        navigator.onCreate(activity, null);
+        navigator.goTo(screen);
+
+        assertThat(navigator.currentScreen()).isEqualTo(screen);
+
+        navigator.onDestroy(activity);
+
+        navigator.rewriteHistory(activity, new HistoryRewriter() {
+            @Override
+            public void rewriteHistory(Deque<Screen> history) {
+                history.pop();
+            }
+        });
+
+        assertThat(navigator.currentScreen()).isEqualTo(root);
+    }
+
+    @Test
+    public void rewriteHistory_differentActivity() {
+        navigator.onCreate(activity, null);
+
+        navigator.rewriteHistory(new NavigatorActivity(), new HistoryRewriter() {
+            @Override
+            public void rewriteHistory(Deque<Screen> history) {
+            }
+        });
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void rewriteHistory_afterOnCreate() {
+        navigator.onCreate(activity, null);
+
+        navigator.rewriteHistory(activity, new HistoryRewriter() {
+            @Override
+            public void rewriteHistory(Deque<Screen> history) {
+            }
+        });
+    }
+
+    @Test
+    public void actionBarConfig() {
+        when(screen.shouldShowActionBar()).thenReturn(true);
+        when(screen.shouldAnimateActionBar()).thenReturn(true);
+        when(screen.getActionBarColorRes()).thenReturn(42);
+
+        navigator.onCreate(activity, null);
+        navigator.goTo(screen);
+
+        verify(screen).onShow(activity);
+        verify(activity, times(2)).onNavigate(isA(ActionBarConfig.class));
+        assertThat(activity.actionBarConfig.visible()).isTrue();
+        assertThat(activity.actionBarConfig.animated()).isTrue();
+        assertThat(activity.actionBarConfig.colorRes()).isEqualTo(42);
+        assertThat(navigator.currentScreen()).isEqualTo(screen);
+    }
+
+    @Test
+    public void navigate() {
+        when(screen.shouldShowActionBar()).thenReturn(false);
+        when(screen2.shouldShowActionBar()).thenReturn(true);
+
+        navigator.onCreate(activity, null);
+        navigator.goTo(screen);
+
+        navigator.navigate(new HistoryRewriter() {
+            @Override
+            public void rewriteHistory(Deque<Screen> history) {
+                history.clear();
+                history.push(root);
+                history.push(screen2);
+            }
+        });
+
+        verify(screen).onHide(activity);
+        verify(screen2).onShow(activity);
+        assertThat(navigator.currentScreen()).isEqualTo(screen2);
+    }
+
+    @Test
+    public void consumeTouchEventsDuringNavigate() {
+        Robolectric.getForegroundThreadScheduler().pause();
+        navigator.onCreate(activity, null);
+        assertThat(container.onInterceptTouchEvent(null)).isFalse();
+
+        navigator.goTo(screen);
+
+        assertThat(container.onInterceptTouchEvent(null)).isTrue();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void goBackTooMuch() {
+        navigator.onCreate(activity, null);
+        navigator.goBack();
+        navigator.goBack();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void onCreateNotCalled() {
+        navigator.goTo(screen);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void noContainer() {
+        activity.findViewById(R.id.magellan_container).setId(0);
+        navigator.onCreate(activity, null);
+    }
+
+    @Test
+    public void getEventsDescription() {
+        navigator.onCreate(activity, null);
+
+        navigator.goTo(screen);
+
+        assertThat(navigator.getEventsDescription()).isEqualTo(
+                "GO FORWARD - Backstack: root > [screen]\n"
+        );
+
+        navigator.goTo(screen2);
+
+        assertThat(navigator.getEventsDescription()).isEqualTo(
+                "GO FORWARD - Backstack: root > [screen]\n" +
+                        "GO FORWARD - Backstack: root > screen > [screen2]\n"
+        );
+
+        navigator.goTo(screen3);
+
+        assertThat(navigator.getEventsDescription()).isEqualTo(
+                "GO FORWARD - Backstack: root > screen > [screen2]\n" +
+                        "GO FORWARD - Backstack: root > screen > screen2 > [screen3]\n"
+        );
+
+        navigator.goBack();
+
+        assertThat(navigator.getEventsDescription()).isEqualTo(
+                "GO FORWARD - Backstack: root > screen > screen2 > [screen3]\n" +
+                        "GO BACKWARD - Backstack: root > screen > [screen2]\n"
+        );
+
+        navigator.show(screen3);
+
+        assertThat(navigator.getEventsDescription()).isEqualTo(
+                "GO BACKWARD - Backstack: root > screen > [screen2]\n" +
+                        "SHOW FORWARD - Backstack: root > screen > screen2 > [screen3]\n"
+        );
+    }
+
+    private static abstract class BaseActivity extends Activity implements NavigationListener, ScreenAwareActivity {
+
+        ActionBarConfig actionBarConfig;
+
+
+        @Override
+        public abstract Context getContext();
+
+        @Override
+        public abstract void onDestroy();
+
+        @Override
+        public void onNavigate(ActionBarConfig actionBarConfig) {
+            this.actionBarConfig = actionBarConfig;
+        }
+    }
+
+    private static class NavigatorActivity extends BaseActivity{
+
+        @Override
+        public Context getContext() {
+            return this;
+        }
+
+        @Override
+        public void onDestroy() {
+
+        }
+    }
 }

--- a/magellan-library/src/test/java/com/wealthfront/magellan/ScreenGroupTest.java
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/ScreenGroupTest.java
@@ -3,6 +3,7 @@ package com.wealthfront.magellan;
 import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
+import android.view.View;
 import android.view.ViewGroup;
 
 import org.junit.Before;
@@ -17,147 +18,183 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 public class ScreenGroupTest {
 
-  private DummyScreen screen1;
-  private DummyScreen screen2;
-  private DummyScreen screen3;
+    private DummyScreen screen1;
+    private DummyScreen screen2;
+    private DummyScreen screen3;
 
-  @Mock BaseScreenView<DummyScreen> view1;
-  @Mock BaseScreenView<DummyScreen> view2;
-  @Mock BaseScreenView<DummyScreen> view3;
-  @Mock BaseScreenView<ScreenGroup> screenGroupView;
+    @Mock
+    BaseScreenView<DummyScreen> view1;
+    @Mock
+    BaseScreenView<DummyScreen> view2;
+    @Mock
+    BaseScreenView<DummyScreen> view3;
+    @Mock
+    BaseScreenView<ScreenGroup> screenGroupView;
 
-  @Mock Bundle bundle;
-  @Mock Context context;
-  @Mock Navigator navigator;
+    @Mock
+    Bundle bundle;
+    @Mock
+    Context context;
+    @Mock
+    Navigator navigator;
 
-  private ScreenGroup screenGroup;
+    private ScreenGroup screenGroup;
 
-  @Before
-  public void setUp() {
-    initMocks(this);
-    screen1 = spy(new DummyScreen(view1));
-    screen2 = spy(new DummyScreen(view2));
-    screen3 = spy(new DummyScreen(view3));
-    screenGroup = new ScreenGroup(asList(screen1, screen2)) {
-      @Override
-      protected ViewGroup createView(Context context) {
-        return screenGroupView;
-      }
-    };
-  }
-
-  @Test
-  public void addScreen() {
-    screenGroup.addScreen(screen3);
-    assertThat(screenGroup.getScreens().size()).isEqualTo(3);
-  }
-
-  @Test
-  public void addScreen_emptyConstructor() {
-    screenGroup = new ScreenGroup() {
-      @Override
-      protected ViewGroup createView(Context context) {
-        return null;
-      }
-    };
-    screenGroup.addScreen(screen1);
-  }
-
-  @Test(expected = IllegalStateException.class)
-  public void addScreen_onCreateCalled() {
-    screen3.recreateView(new Activity(), navigator);
-    screenGroup.addScreen(screen3);
-  }
-
-  @Test(expected = IllegalStateException.class)
-  public void addScreen_thisOnCreateCalled() {
-    screenGroup.recreateView(new Activity(), navigator);
-    screenGroup.addScreen(screen3);
-  }
-
-  @Test
-  public void addScreens() {
-    screenGroup = new ScreenGroup() {
-      @Override
-      protected ViewGroup createView(Context context) {
-        return null;
-      }
-    };
-    screenGroup.addScreens(asList(screen1, screen2));
-  }
-
-  @Test(expected = IllegalStateException.class)
-  public void addScreens_thisOnCreateCalled() {
-    screenGroup.recreateView(new Activity(), navigator);
-    screenGroup.addScreens(asList(screen3));
-  }
-
-  @Test(expected = IllegalStateException.class)
-  public void addScreens_onCreateCalled() {
-    screen3.recreateView(new Activity(), navigator);
-    screenGroup.addScreens(asList(screen3));
-  }
-
-  @Test
-  public void onShow() {
-    screenGroup.onShow(context);
-    verify(screen1).onShow(context);
-    verify(screen2).onShow(context);
-  }
-
-  @Test
-  public void onRestore() {
-    screenGroup.onRestore(bundle);
-    verify(screen1).onRestore(bundle);
-    verify(screen2).onRestore(bundle);
-  }
-
-  @Test
-  public void onResume() {
-    screenGroup.onResume(context);
-    verify(screen1).onResume(context);
-    verify(screen2).onResume(context);
-  }
-
-  @Test
-  public void onPause() {
-    screenGroup.onPause(context);
-    verify(screen1).onPause(context);
-    verify(screen2).onPause(context);
-  }
-
-  @Test
-  public void onSave() {
-    screenGroup.onSave(bundle);
-    verify(screen1).onSave(bundle);
-    verify(screen2).onSave(bundle);
-  }
-
-  @Test
-  public void onHide() {
-    screenGroup.onHide(context);
-    verify(screen1).onHide(context);
-    verify(screen2).onHide(context);
-    assertThat(screen1.getDialog()).isNull();
-    assertThat(screen1.getView()).isNull();
-    assertThat(screen2.getDialog()).isNull();
-    assertThat(screen2.getView()).isNull();
-  }
-
-  private static class DummyScreen extends Screen<BaseScreenView<DummyScreen>> {
-
-    private BaseScreenView<DummyScreen> view;
-
-    DummyScreen(BaseScreenView<DummyScreen> view) {
-      this.view = view;
-      setView(view);
+    @Before
+    public void setUp() {
+        initMocks(this);
+        screen1 = spy(new DummyScreen(view1));
+        screen2 = spy(new DummyScreen(view2));
+        screen3 = spy(new DummyScreen(view3));
+        screenGroup = new ScreenGroup(asList(screen1, screen2)) {
+            @Override
+            protected ViewGroup createView(Context context) {
+                return screenGroupView;
+            }
+        };
     }
 
-    @Override
-    protected BaseScreenView<DummyScreen> createView(Context context) {
-      return view;
+    @Test
+    public void addScreen() {
+        screenGroup.addScreen(screen3);
+        assertThat(screenGroup.getScreens().size()).isEqualTo(3);
     }
 
-  }
+    @Test
+    public void addScreen_emptyConstructor() {
+        screenGroup = new ScreenGroup() {
+            @Override
+            protected ViewGroup createView(Context context) {
+                return null;
+            }
+        };
+        screenGroup.addScreen(screen1);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void addScreen_onCreateCalled() {
+        screen3.recreateView(new NavigatorActivity(), navigator);
+        screenGroup.addScreen(screen3);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void addScreen_thisOnCreateCalled() {
+        screenGroup.recreateView(new NavigatorActivity(), navigator);
+        screenGroup.addScreen(screen3);
+    }
+
+    @Test
+    public void addScreens() {
+        screenGroup = new ScreenGroup() {
+            @Override
+            protected ViewGroup createView(Context context) {
+                return null;
+            }
+        };
+        screenGroup.addScreens(asList(screen1, screen2));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void addScreens_thisOnCreateCalled() {
+        screenGroup.recreateView(new NavigatorActivity(), navigator);
+        screenGroup.addScreens(asList(screen3));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void addScreens_onCreateCalled() {
+        screen3.recreateView(new NavigatorActivity(), navigator);
+        screenGroup.addScreens(asList(screen3));
+    }
+
+    @Test
+    public void onShow() {
+        screenGroup.onShow(context);
+        verify(screen1).onShow(context);
+        verify(screen2).onShow(context);
+    }
+
+    @Test
+    public void onRestore() {
+        screenGroup.onRestore(bundle);
+        verify(screen1).onRestore(bundle);
+        verify(screen2).onRestore(bundle);
+    }
+
+    @Test
+    public void onResume() {
+        screenGroup.onResume(context);
+        verify(screen1).onResume(context);
+        verify(screen2).onResume(context);
+    }
+
+    @Test
+    public void onPause() {
+        screenGroup.onPause(context);
+        verify(screen1).onPause(context);
+        verify(screen2).onPause(context);
+    }
+
+    @Test
+    public void onSave() {
+        screenGroup.onSave(bundle);
+        verify(screen1).onSave(bundle);
+        verify(screen2).onSave(bundle);
+    }
+
+    @Test
+    public void onHide() {
+        screenGroup.onHide(context);
+        verify(screen1).onHide(context);
+        verify(screen2).onHide(context);
+        assertThat(screen1.getDialog()).isNull();
+        assertThat(screen1.getView()).isNull();
+        assertThat(screen2.getDialog()).isNull();
+        assertThat(screen2.getView()).isNull();
+    }
+
+    private static class DummyScreen extends Screen<BaseScreenView<DummyScreen>> {
+
+        private BaseScreenView<DummyScreen> view;
+
+        DummyScreen(BaseScreenView<DummyScreen> view) {
+            this.view = view;
+            setView(view);
+        }
+
+        @Override
+        protected BaseScreenView<DummyScreen> createView(Context context) {
+            return view;
+        }
+
+    }
+
+    private static abstract class BaseActivity extends Activity implements NavigationListener, ScreenAwareActivity {
+
+        ActionBarConfig actionBarConfig;
+
+        @Override
+        public abstract Context getContext();
+
+        @Override
+        public abstract void onDestroy();
+
+        @Override
+        public void onNavigate(ActionBarConfig actionBarConfig) {
+            this.actionBarConfig = actionBarConfig;
+        }
+    }
+
+    private static class NavigatorActivity extends BaseActivity {
+
+        @Override
+        public Context getContext() {
+            return this;
+        }
+
+        @Override
+        public void onDestroy() {
+
+        }
+    }
 
 }

--- a/magellan-library/src/test/java/com/wealthfront/magellan/ScreenTest.java
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/ScreenTest.java
@@ -62,33 +62,6 @@ public class ScreenTest {
   }
 
   @Test
-  public void createDialog() {
-    screen.showDialog(new DialogCreator() {
-      @Override
-      public Dialog createDialog(Activity activity) {
-        return dialog;
-      }
-    });
-    screen.createDialog();
-
-    verify(dialog, times(2)).show();
-  }
-
-  @Test
-  public void destroyDialog() {
-    screen.showDialog(new DialogCreator() {
-      @Override
-      public Dialog createDialog(Activity activity) {
-        return dialog;
-      }
-    });
-    screen.destroyDialog();
-
-    verify(dialog).setOnDismissListener(null);
-    verify(dialog).dismiss();
-  }
-
-  @Test
   public void saveRestore() {
     final Bundle state42 = new Bundle();
     state42.putString("key", "value");

--- a/magellan-rx/build.gradle
+++ b/magellan-rx/build.gradle
@@ -8,7 +8,7 @@ android {
   buildToolsVersion "25.0.1"
 
   defaultConfig {
-    minSdkVersion 15
+    minSdkVersion 21
     targetSdkVersion 25
     versionCode 1
     versionName "1.0"

--- a/magellan-rx2/build.gradle
+++ b/magellan-rx2/build.gradle
@@ -8,7 +8,7 @@ android {
   buildToolsVersion "25.0.1"
 
   defaultConfig {
-    minSdkVersion 15
+    minSdkVersion 21
     targetSdkVersion 25
     versionCode 1
     versionName "1.0"

--- a/magellan-sample-advanced/build.gradle
+++ b/magellan-sample-advanced/build.gradle
@@ -5,7 +5,7 @@ android {
   buildToolsVersion "25.0.1"
   defaultConfig {
     applicationId "com.wealthfront.magellan.sample"
-    minSdkVersion 15
+    minSdkVersion 21
     targetSdkVersion 25
     versionCode 1
     versionName "1.0"

--- a/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/MainActivity.java
+++ b/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/MainActivity.java
@@ -1,15 +1,18 @@
 package com.wealthfront.magellan.sample.advanced;
 
+import android.content.Context;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 
+import com.wealthfront.magellan.ActionBarConfig;
 import com.wealthfront.magellan.Navigator;
+import com.wealthfront.magellan.ScreenAwareActivity;
 
 import javax.inject.Inject;
 
 import static com.wealthfront.magellan.sample.advanced.SampleApplication.app;
 
-public class MainActivity extends AppCompatActivity {
+public class MainActivity extends AppCompatActivity implements ScreenAwareActivity {
 
   @Inject Navigator navigator;
 
@@ -26,6 +29,16 @@ public class MainActivity extends AppCompatActivity {
     if (!navigator.handleBack()) {
       super.onBackPressed();
     }
+  }
+
+  @Override
+  public Context getContext() {
+    return this;
+  }
+
+  @Override
+  public void onDestroy() {
+    super.onDestroy();
   }
 
 }

--- a/magellan-sample/build.gradle
+++ b/magellan-sample/build.gradle
@@ -5,7 +5,7 @@ android {
   buildToolsVersion "25.0.1"
   defaultConfig {
     applicationId "com.wealthfront.magellan.sample"
-    minSdkVersion 15
+    minSdkVersion 21
     targetSdkVersion 25
     versionCode 1
     versionName "1.0"

--- a/magellan-sample/src/main/java/com/wealthfront/magellan/sample/MainActivity.java
+++ b/magellan-sample/src/main/java/com/wealthfront/magellan/sample/MainActivity.java
@@ -7,15 +7,15 @@ import com.wealthfront.magellan.support.SingleActivity;
 
 public class MainActivity extends SingleActivity {
 
-  @Override
-  protected Navigator createNavigator() {
-    return Navigator.withRoot(new HomeScreen()).loggingEnabled(true).build();
-  }
+    @Override
+    protected Navigator createNavigator() {
+        return Navigator.withRoot(new HomeScreen()).loggingEnabled(true).build();
+    }
 
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    setContentView(R.layout.main_activity);
-  }
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.main_activity);
+    }
 
 }

--- a/magellan-support/build.gradle
+++ b/magellan-support/build.gradle
@@ -8,7 +8,7 @@ android {
   buildToolsVersion "25.0.1"
 
   defaultConfig {
-    minSdkVersion 15
+    minSdkVersion 21
     targetSdkVersion 25
     versionCode 1
     versionName "1.0"

--- a/magellan-support/src/main/java/com/wealthfront/magellan/support/SingleActivity.java
+++ b/magellan-support/src/main/java/com/wealthfront/magellan/support/SingleActivity.java
@@ -1,76 +1,83 @@
 package com.wealthfront.magellan.support;
 
+import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 
+import com.wealthfront.magellan.ActionBarConfig;
 import com.wealthfront.magellan.Navigator;
+import com.wealthfront.magellan.ScreenAwareActivity;
 
-public abstract class SingleActivity extends AppCompatActivity {
+public abstract class SingleActivity extends AppCompatActivity implements ScreenAwareActivity {
 
-  private static Navigator navigator;
+    private static Navigator navigator;
 
-  protected abstract Navigator createNavigator();
+    protected abstract Navigator createNavigator();
 
-  public static Navigator getNavigator() {
-    return navigator;
-  }
-
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    if (navigator == null) {
-      navigator = createNavigator();
+    public static Navigator getNavigator() {
+        return navigator;
     }
-  }
 
-  @Override
-  protected void onPostCreate(@Nullable Bundle savedInstanceState) {
-    navigator.onCreate(this, savedInstanceState);
-    super.onPostCreate(savedInstanceState);
-  }
-
-  @Override
-  public void onSaveInstanceState(Bundle outState) {
-    navigator.onSaveInstanceState(outState);
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    navigator.onResume(this);
-  }
-
-  @Override
-  protected void onPause() {
-    navigator.onPause(this);
-    super.onPause();
-  }
-
-  @Override
-  protected void onDestroy() {
-    navigator.onDestroy(this);
-    super.onDestroy();
-  }
-
-  @Override
-  public void onBackPressed() {
-    if (!navigator.handleBack()) {
-      super.onBackPressed();
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (navigator == null) {
+            navigator = createNavigator();
+        }
     }
-  }
 
-  @Override
-  public boolean onCreateOptionsMenu(Menu menu) {
-    navigator.onCreateOptionsMenu(menu);
-    return super.onCreateOptionsMenu(menu);
-  }
+    @Override
+    protected void onPostCreate(@Nullable Bundle savedInstanceState) {
+        navigator.onCreate(this, savedInstanceState);
+        super.onPostCreate(savedInstanceState);
+    }
 
-  @Override
-  public boolean onPrepareOptionsMenu(Menu menu) {
-    navigator.onPrepareOptionsMenu(menu);
-    return super.onPrepareOptionsMenu(menu);
-  }
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        navigator.onSaveInstanceState(outState);
+    }
 
+    @Override
+    protected void onResume() {
+        super.onResume();
+        navigator.onResume(this);
+    }
+
+    @Override
+    protected void onPause() {
+        navigator.onPause(this);
+        super.onPause();
+    }
+
+    @Override
+    public void onDestroy() {
+        navigator.onDestroy(this);
+        super.onDestroy();
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (!navigator.handleBack()) {
+            super.onBackPressed();
+        }
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        navigator.onCreateOptionsMenu(menu);
+        return super.onCreateOptionsMenu(menu);
+    }
+
+    @Override
+    public boolean onPrepareOptionsMenu(Menu menu) {
+        navigator.onPrepareOptionsMenu(menu);
+        return super.onPrepareOptionsMenu(menu);
+    }
+
+    @Override
+    public Context getContext() {
+        return this;
+    }
 }


### PR DESCRIPTION
Implemented an interface called ScreenAwareActivity that adds flexibility to library consumers. This change allows a developer to not be forced into using Activity, it changes the system to rely on Context and not Activity. This is a breaking change as it requires developers to implement the new interface.

I made this change because I was unable to use an Activity in a project but still wanted to use the Magellan library. 