### PR TITLE
Subtly change the definition of whenTransitionFinished

### DIFF
--- a/magellan-library/src/main/java/com/wealthfront/magellan/Navigator.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/Navigator.java
@@ -552,7 +552,6 @@ public class Navigator implements BackHandler {
     whenMeasured(to, new Views.OnMeasured() {
       @Override
       public void onMeasured() {
-        currentScreen().transitionStarted();
         transitionToUse.animate(from, to, navType, direction, new Transition.Callback() {
           @Override
           public void onAnimationEnd() {
@@ -576,6 +575,7 @@ public class Navigator implements BackHandler {
   }
 
   private View showCurrentScreen(Direction direction) {
+    currentScreen().transitionStarted();
     Screen currentScreen = currentScreen();
     View view = currentScreen.recreateView(activity, this);
     container.addView(view, direction == FORWARD ? container.getChildCount() : 0);

--- a/magellan-library/src/main/java/com/wealthfront/magellan/Screen.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/Screen.java
@@ -147,8 +147,8 @@ public abstract class Screen<V extends ViewGroup & ScreenView> implements BackHa
   }
 
   /**
-   * Adds a {@link TransitionFinishedListener} to be called when the navigation transition into the screen is finished,
-   * or immediately if the screen is not currently transitioning.
+   * Adds a {@link TransitionFinishedListener} to be called when the navigation transition into this screen is finished,
+   * or immediately if the transition is already finished.
    * @param listener The listener to be called when the transition is finished or immediately.
    */
   protected final void whenTransitionFinished(TransitionFinishedListener listener) {
@@ -287,12 +287,13 @@ public abstract class Screen<V extends ViewGroup & ScreenView> implements BackHa
   }
 
   /**
-   * A simple interface with a method to be run when the screen's transition is finished.
+   * A simple interface with a method to be run when the transition to this screen is finished, or immediately if it's
+   * already finished.
    */
   public interface TransitionFinishedListener {
 
     /**
-     * The method to run when the screen's transition is finished.
+     * The method to run when the transition to this screen is finished.
      */
     void onTransitionFinished();
 


### PR DESCRIPTION
Make it so all actions passed to `whenTransitionFinished { }` from `createView()` on are delayed until the transition is finished (including `onShow`). Also, clarify documentation.

Previously, we immediately ran any code passed to `whenTransitionFinished { }` before the view was measured, which is unintuitive and could have unintended consequences.