### PR TITLE
Change default transition

### DIFF
--- a/magellan-library/src/main/java/com/wealthfront/magellan/transitions/DefaultTransition.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/transitions/DefaultTransition.java
@@ -8,6 +8,8 @@ import android.animation.TimeInterpolator;
 import android.util.Property;
 import android.view.View;
 import android.view.animation.AccelerateDecelerateInterpolator;
+import android.view.animation.AccelerateInterpolator;
+import android.view.animation.DecelerateInterpolator;
 
 import com.wealthfront.magellan.Direction;
 import com.wealthfront.magellan.NavigationType;
@@ -18,13 +20,15 @@ import static com.wealthfront.magellan.Direction.FORWARD;
 public class DefaultTransition implements Transition {
 
   private TimeInterpolator customGoInterpolator = new AccelerateDecelerateInterpolator();
-  private TimeInterpolator customShowInterpolator = new AccelerateDecelerateInterpolator();
-  private TimeInterpolator customHideInterpolator = new AccelerateDecelerateInterpolator();
+  private TimeInterpolator customShowInterpolator = new DecelerateInterpolator();
+  private TimeInterpolator customHideInterpolator = new AccelerateInterpolator();
 
   public DefaultTransition() { }
 
   public DefaultTransition(TimeInterpolator customInterpolator) {
     this.customGoInterpolator = customInterpolator;
+    this.customShowInterpolator = customInterpolator;
+    this.customHideInterpolator = customInterpolator;
   }
 
   public DefaultTransition(TimeInterpolator customGoInterpolator, TimeInterpolator customShowInterpolator,
@@ -51,6 +55,7 @@ public class DefaultTransition implements Transition {
     int fromTranslation;
     int toTranslation;
     int sign = direction.sign();
+    TimeInterpolator interpolator = customGoInterpolator;
 
     switch (navType) {
       case GO:
@@ -62,6 +67,7 @@ public class DefaultTransition implements Transition {
         axis = View.TRANSLATION_Y;
         fromTranslation = direction == FORWARD ? 0 : from.getHeight();
         toTranslation = direction == BACKWARD ? 0 : to.getHeight();
+        interpolator = direction == FORWARD ? customShowInterpolator : customHideInterpolator;
         break;
       default:
         axis = View.TRANSLATION_X;
@@ -73,11 +79,11 @@ public class DefaultTransition implements Transition {
     ObjectAnimator animator;
     if (from != null) {
       animator = ObjectAnimator.ofFloat(from, axis, 0, fromTranslation);
-      animator.setInterpolator(customGoInterpolator);
+      animator.setInterpolator(interpolator);
       set.play(animator);
     }
     animator = ObjectAnimator.ofFloat(to, axis, toTranslation, 0);
-    animator.setInterpolator(customGoInterpolator);
+    animator.setInterpolator(interpolator);
     set.play(animator);
     return set;
   }

--- a/magellan-library/src/main/java/com/wealthfront/magellan/transitions/DefaultTransition.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/transitions/DefaultTransition.java
@@ -4,8 +4,10 @@ import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.animation.AnimatorSet;
 import android.animation.ObjectAnimator;
+import android.animation.TimeInterpolator;
 import android.util.Property;
 import android.view.View;
+import android.view.animation.AccelerateDecelerateInterpolator;
 
 import com.wealthfront.magellan.Direction;
 import com.wealthfront.magellan.NavigationType;
@@ -14,6 +16,23 @@ import static com.wealthfront.magellan.Direction.BACKWARD;
 import static com.wealthfront.magellan.Direction.FORWARD;
 
 public class DefaultTransition implements Transition {
+
+  private TimeInterpolator customGoInterpolator = new AccelerateDecelerateInterpolator();
+  private TimeInterpolator customShowInterpolator = new AccelerateDecelerateInterpolator();
+  private TimeInterpolator customHideInterpolator = new AccelerateDecelerateInterpolator();
+
+  public DefaultTransition() { }
+
+  public DefaultTransition(TimeInterpolator customInterpolator) {
+    this.customGoInterpolator = customInterpolator;
+  }
+
+  public DefaultTransition(TimeInterpolator customGoInterpolator, TimeInterpolator customShowInterpolator,
+                           TimeInterpolator customHideInterpolator) {
+    this.customGoInterpolator = customGoInterpolator;
+    this.customShowInterpolator = customShowInterpolator;
+    this.customHideInterpolator = customHideInterpolator;
+  }
 
   @Override
   public final void animate(View from, View to, NavigationType navType, Direction direction, final Callback callback) {
@@ -51,10 +70,15 @@ public class DefaultTransition implements Transition {
         break;
     }
     AnimatorSet set = new AnimatorSet();
+    ObjectAnimator animator;
     if (from != null) {
-      set.play(ObjectAnimator.ofFloat(from, axis, 0, fromTranslation));
+      animator = ObjectAnimator.ofFloat(from, axis, 0, fromTranslation);
+      animator.setInterpolator(customGoInterpolator);
+      set.play(animator);
     }
-    set.play(ObjectAnimator.ofFloat(to, axis, toTranslation, 0));
+    animator = ObjectAnimator.ofFloat(to, axis, toTranslation, 0);
+    animator.setInterpolator(customGoInterpolator);
+    set.play(animator);
     return set;
   }
 }


### PR DESCRIPTION
The default transition handles almost all of the normal transition styles, but it uses the default `AccelerateDecelerateInterpolator`, whereas material design guidelines recommend the `FastOutSlowInInterpolator`. Unfortunately, the `FastOutSlowInInterpolator` is part of the support library, which would be too large to include in Magellan.

I propose we add the ability to set the interpolators for the default transition to support this and other cases. Also, I propose that we allow different interpolators for `NavigationType.GO` vs. `SHOW` vs. `HIDE`, since they are all different animations.

(Note: it looks like they're splitting the interpolators out into a separate package in support library v28, but that's in alpha right now.)