### PR TITLE
Pass onActivityResult event to current Screen

### DIFF
--- a/magellan-library/src/main/java/com/wealthfront/magellan/Navigator.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/Navigator.java
@@ -1,8 +1,10 @@
 package com.wealthfront.magellan;
 
 import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.Menu;
@@ -23,10 +25,10 @@ import static com.wealthfront.magellan.Direction.FORWARD;
 import static com.wealthfront.magellan.NavigationType.GO;
 import static com.wealthfront.magellan.NavigationType.NO_ANIM;
 import static com.wealthfront.magellan.NavigationType.SHOW;
-import static com.wealthfront.magellan.Views.whenMeasured;
 import static com.wealthfront.magellan.Preconditions.checkArgument;
 import static com.wealthfront.magellan.Preconditions.checkNotNull;
 import static com.wealthfront.magellan.Preconditions.checkState;
+import static com.wealthfront.magellan.Views.whenMeasured;
 
 /**
  * Class responsible for navigating between screens and maintaining collection of screens in a back stack.
@@ -151,6 +153,24 @@ public class Navigator implements BackHandler {
   public void onResume(Activity activity) {
     if (sameActivity(activity)) {
       currentScreen().onResume(activity);
+    }
+  }
+
+  /**
+   * Notifies Navigator that the activity's onActivityResult callback has been hit. Call this method from
+   * {@code onActivityResult} of the Activity associated with this Navigator.
+   *
+   * This method will notify the current screen of the event if the activity parameter is the same as the
+   * activity provided to this Navigator in {@link #onCreate(Activity, Bundle) onCreate}.
+   *
+   * @param requestCode  the request code originally supplied to startActivityForResult()
+   * @param resultCode	the result code returned by the child activity through its setResult()
+   * @param data	result data for the caller
+   *
+   */
+  public void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
+    if (sameActivity(activity)) {
+      currentScreen().onActivityResult(requestCode, resultCode, data);
     }
   }
 

--- a/magellan-library/src/main/java/com/wealthfront/magellan/Screen.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/Screen.java
@@ -3,9 +3,11 @@ package com.wealthfront.magellan;
 import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.annotation.ColorRes;
+import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.support.annotation.VisibleForTesting;
 import android.util.SparseArray;
@@ -197,6 +199,11 @@ public abstract class Screen<V extends ViewGroup & ScreenView> implements BackHa
    * Override this method to dynamically change the menu.
    */
   protected void onUpdateMenu(Menu menu) {}
+
+  /**
+   * Called when the Activity receives a result from a startActivityForResult call
+   */
+  protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {}
 
   /**
    * Called when the Activity is resumed and when the Screen is shown.

--- a/magellan-library/src/test/java/com/wealthfront/magellan/NavigatorTest.java
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/NavigatorTest.java
@@ -149,6 +149,23 @@ public class NavigatorTest {
   }
 
   @Test
+  public void onActivityResult() {
+    navigator.onCreate(activity, null);
+    reset(root);
+    navigator.onActivityResult(1138, Activity.RESULT_OK, null);
+
+    verify(root).onActivityResult(1138, Activity.RESULT_OK, null);
+  }
+
+  @Test
+  public void onActivityResult_differentActivity() {
+    navigator.onCreate(activity, null);
+    reset(root);
+    verifyNoMoreInteractions(root);
+    navigator.onActivityResult(1138, Activity.RESULT_OK, null);
+  }
+
+  @Test
   public void lifecycleListener() {
     navigator.addLifecycleListener(lifecycleListener);
     navigator.onCreate(activity, null);


### PR DESCRIPTION
like other Activity-level events (onResume/onPause), developers would pass this through the Navigator instance in order to reach its current screen.