### PR TITLE
Add ability to listen to lifecycle events on Helper classes

### DIFF
--- a/magellan-library/build.gradle
+++ b/magellan-library/build.gradle
@@ -36,6 +36,8 @@ apply from: rootProject.file('checkstyle/checkstyle.gradle')
 dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
   implementation "androidx.appcompat:appcompat:${SUPPORT_LIBRARY_VERSION}"
+  implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.2.0"
+  implementation "androidx.lifecycle:lifecycle-common-java8:2.2.0"
 
   testImplementation "junit:junit:${JUNIT_VERSION}"
   testImplementation "com.google.truth:truth:${TRUTH_VERSION}"

--- a/magellan-library/src/main/java/com/wealthfront/magellan/Navigator.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/Navigator.java
@@ -89,7 +89,6 @@ public class Navigator implements BackHandler {
     checkState(container != null, "There must be a ScreenContainer whose id is R.id.magellan_container in the view hierarchy");
     for (Screen screen : backStack) {
       screen.restore(savedInstanceState);
-      screen.onRestore(savedInstanceState);
     }
     showCurrentScreen(FORWARD);
   }
@@ -105,7 +104,6 @@ public class Navigator implements BackHandler {
   public void onSaveInstanceState(Bundle outState) {
     for (Screen screen : backStack) {
       screen.save(outState);
-      screen.onSave(outState);
     }
   }
 
@@ -150,7 +148,7 @@ public class Navigator implements BackHandler {
    */
   public void onResume(Activity activity) {
     if (sameActivity(activity)) {
-      currentScreen().onResume(activity);
+      currentScreen().resume(activity);
     }
   }
 
@@ -165,7 +163,7 @@ public class Navigator implements BackHandler {
    */
   public void onPause(Activity activity) {
     if (sameActivity(activity)) {
-      currentScreen().onPause(activity);
+      currentScreen().pause(activity);
     }
   }
 
@@ -584,7 +582,7 @@ public class Navigator implements BackHandler {
     container.addView(view, direction == FORWARD ? container.getChildCount() : 0);
     currentScreen.createDialog();
     activity.setTitle(currentScreen.getTitle(activity));
-    currentScreen.onShow(activity);
+    currentScreen.show(activity);
     for (ScreenLifecycleListener lifecycleListener : lifecycleListeners) {
       lifecycleListener.onShow(currentScreen);
     }
@@ -611,7 +609,8 @@ public class Navigator implements BackHandler {
     for (ScreenLifecycleListener lifecycleListener : lifecycleListeners) {
       lifecycleListener.onHide(currentScreen);
     }
-    currentScreen.onHide(activity);
+    currentScreen.hide(activity);
+    currentScreen.clearLifecycleListeners();
     currentScreen.destroyDialog();
     currentScreen.destroyView();
     View view = container.getChildAt(0); // will be removed at the end of the animation

--- a/magellan-library/src/main/java/com/wealthfront/magellan/Screen.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/Screen.java
@@ -18,6 +18,7 @@ import java.util.Queue;
 import java.util.function.Consumer;
 
 import androidx.annotation.ColorRes;
+import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 import androidx.annotation.VisibleForTesting;
 
@@ -315,12 +316,12 @@ public abstract class Screen<V extends ViewGroup & ScreenView> implements BackHa
     checkState(activity == null, reason);
   }
 
-  public final void addLifecycleListener(LifecycleListener LifecycleListener) {
-    lifecycleListeners.add(LifecycleListener);
+  public final void addLifecycleListener(@NonNull LifecycleListener lifecycleListener) {
+    lifecycleListeners.add(lifecycleListener);
   }
 
-  public final void removeLifecycleListener(LifecycleListener LifecycleListener) {
-    lifecycleListeners.remove(lifecycleListeners);
+  public final void removeLifecycleListener(@NonNull LifecycleListener lifecycleListener) {
+    lifecycleListeners.remove(lifecycleListener);
   }
 
   public final void clearLifecycleListeners() {

--- a/magellan-library/src/main/java/com/wealthfront/magellan/ScreenGroup.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/ScreenGroup.java
@@ -40,7 +40,7 @@ public abstract class ScreenGroup<S extends Screen, V extends ViewGroup & Screen
     for (Screen screen : screens) {
       screen.recreateView(getActivity());
       screen.createDialog();
-      screen.onShow(context);
+      screen.show(context);
     }
   }
 
@@ -54,14 +54,14 @@ public abstract class ScreenGroup<S extends Screen, V extends ViewGroup & Screen
   @Override
   protected void onResume(Context context) {
     for (Screen screen : screens) {
-      screen.onResume(context);
+      screen.resume(context);
     }
   }
 
   @Override
   protected void onPause(Context context) {
     for (Screen screen : screens) {
-      screen.onPause(context);
+      screen.pause(context);
     }
   }
 
@@ -75,7 +75,7 @@ public abstract class ScreenGroup<S extends Screen, V extends ViewGroup & Screen
   @Override
   protected void onHide(Context context) {
     for (Screen screen : screens) {
-      screen.onHide(context);
+      screen.hide(context);
       screen.destroyDialog();
       screen.destroyView();
     }

--- a/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleListener.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleListener.kt
@@ -1,0 +1,20 @@
+package com.wealthfront.magellan.lifecycle
+
+import android.content.Context
+import android.os.Bundle
+
+interface LifecycleListener {
+
+  fun onShow(context: Context)
+
+  fun onResume(context: Context)
+
+  fun onPause(context: Context)
+
+  fun onHide(context: Context)
+
+  fun onSave(outState: Bundle)
+
+  fun onRestore(savedInstanceState: Bundle)
+
+}

--- a/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleListener.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleListener.kt
@@ -5,16 +5,16 @@ import android.os.Bundle
 
 interface LifecycleListener {
 
-  fun onShow(context: Context)
+  fun onShow(context: Context) {}
 
-  fun onResume(context: Context)
+  fun onResume(context: Context) {}
 
-  fun onPause(context: Context)
+  fun onPause(context: Context) {}
 
-  fun onHide(context: Context)
+  fun onHide(context: Context) {}
 
-  fun onSave(outState: Bundle)
+  fun onSave(outState: Bundle) {}
 
-  fun onRestore(savedInstanceState: Bundle)
+  fun onRestore(savedInstanceState: Bundle) {}
 
 }

--- a/magellan-sample-advanced/build.gradle
+++ b/magellan-sample-advanced/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
 
 android {
   compileSdkVersion 30
@@ -39,7 +40,10 @@ dependencies {
   implementation project(':magellan-library')
   implementation project(':magellan-rx')
 
+  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
   implementation "com.android.support:appcompat-v7:${SUPPORT_LIBRARY_VERSION}"
+  implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.2.0"
+  implementation "androidx.lifecycle:lifecycle-common-java8:2.2.0"
   implementation 'com.jakewharton:butterknife:10.0.0'
   annotationProcessor 'com.jakewharton:butterknife-compiler:10.0.0'
 

--- a/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/MainActivity.java
+++ b/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/MainActivity.java
@@ -1,13 +1,14 @@
 package com.wealthfront.magellan.sample.advanced;
 
-import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
 
 import com.wealthfront.magellan.Navigator;
 
 import javax.inject.Inject;
 
-import static com.wealthfront.magellan.sample.advanced.SampleApplication.app;
+import androidx.appcompat.app.AppCompatActivity;
+
+import static com.wealthfront.magellan.sample.advanced.SampleApplication.injector;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -17,8 +18,9 @@ public class MainActivity extends AppCompatActivity {
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
-    app(this).injector().inject(this);
+    injector().inject(this);
     navigator.onCreate(this, savedInstanceState);
+    getLifecycle().addObserver(navigator);
   }
 
   @Override

--- a/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/SampleApplication.java
+++ b/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/SampleApplication.java
@@ -5,11 +5,7 @@ import android.content.Context;
 
 public class SampleApplication extends Application {
 
-  private AppComponent appComponent;
-
-  public static SampleApplication app(Context context) {
-    return (SampleApplication) context.getApplicationContext();
-  }
+  private static AppComponent appComponent;
 
   @Override
   public void onCreate() {
@@ -17,7 +13,7 @@ public class SampleApplication extends Application {
     appComponent = DaggerAppComponent.builder().appModule(new AppModule()).build();
   }
 
-  public AppComponent injector() {
+  public static AppComponent injector() {
     return appComponent;
   }
 

--- a/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/lifecycle/LifecycleLogger.kt
+++ b/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/lifecycle/LifecycleLogger.kt
@@ -1,0 +1,36 @@
+package com.wealthfront.magellan.sample.advanced.lifecycle
+
+import android.content.Context
+import android.os.Bundle
+import android.util.Log
+import com.wealthfront.magellan.lifecycle.LifecycleListener
+import javax.inject.Inject
+
+private const val TAG = "LifecycleLogger"
+
+class LifecycleLogger @Inject constructor() : LifecycleListener {
+
+  override fun onShow(context: Context) {
+    Log.d(TAG, "onShow called")
+  }
+
+  override fun onResume(context: Context) {
+    Log.d(TAG, "onResume called")
+  }
+
+  override fun onPause(context: Context) {
+    Log.d(TAG, "onPause called")
+  }
+
+  override fun onHide(context: Context) {
+    Log.d(TAG, "onHide called")
+  }
+
+  override fun onSave(outState: Bundle) {
+    Log.d(TAG, "onSave called")
+  }
+
+  override fun onRestore(savedInstanceState: Bundle) {
+    Log.d(TAG, "onRestore called")
+  }
+}

--- a/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/tide/TideDetailsScreen.java
+++ b/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/tide/TideDetailsScreen.java
@@ -6,6 +6,7 @@ import android.widget.Toast;
 import com.wealthfront.magellan.rx.RxScreen;
 import com.wealthfront.magellan.sample.advanced.NoaaApi;
 import com.wealthfront.magellan.sample.advanced.R;
+import com.wealthfront.magellan.sample.advanced.lifecycle.LifecycleLogger;
 import com.wealthfront.magellan.sample.advanced.model.Observation;
 import com.wealthfront.magellan.sample.advanced.model.TideInfo;
 
@@ -19,7 +20,7 @@ import javax.inject.Inject;
 
 import rx.functions.Action1;
 
-import static com.wealthfront.magellan.sample.advanced.SampleApplication.app;
+import static com.wealthfront.magellan.sample.advanced.SampleApplication.injector;
 import static rx.android.schedulers.AndroidSchedulers.mainThread;
 
 public class TideDetailsScreen extends RxScreen<TideDetailsView> {
@@ -32,17 +33,20 @@ public class TideDetailsScreen extends RxScreen<TideDetailsView> {
   };
 
   @Inject NoaaApi noaaApi;
+  @Inject LifecycleLogger lifecycleLogger;
+
   private final String tideLocationName;
   int noaaApiId;
 
   TideDetailsScreen(int noaaApiId, String tideLocationName) {
     this.noaaApiId = noaaApiId;
     this.tideLocationName = tideLocationName;
+    injector().inject(this);
+    addLifecycleListener(lifecycleLogger);
   }
 
   @Override
   protected TideDetailsView createView(Context context) {
-    app(context).injector().inject(this);
     return new TideDetailsView(context);
   }
 


### PR DESCRIPTION
So this is useful when we want to listen to lifecycle events in classes where we are making API calls and we want to cancel them when we navigate away from the screen. This PR adds the ability for object to attach itself to the lifecycle of the screen.

Also as a bonus, this PR also integrates the android lifecycle components to the navigator so that we don't need to manually call the `onResume`, `onPause` and `onDestroy` method anymore.