### PR TITLE
Add lint rule to ensure lifecycle aware are attached to lifecycle owners

### DIFF
--- a/magellan-lint/src/main/java/com/wealthfront/magellan/EnforceLifecycleAwareAttachment.kt
+++ b/magellan-lint/src/main/java/com/wealthfront/magellan/EnforceLifecycleAwareAttachment.kt
@@ -1,0 +1,58 @@
+package com.wealthfront.magellan
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.LintFix
+import com.android.tools.lint.detector.api.Scope.Companion.JAVA_FILE_SCOPE
+import com.android.tools.lint.detector.api.Severity.ERROR
+import org.jetbrains.uast.UField
+import org.jetbrains.uast.util.isConstructorCall
+
+internal val ENFORCE_LIFECYCLE_AWARE_ATTACHMENT = Issue.create(
+  id = EnforceLifecycleAwareAttachment::class.simpleName!!,
+  briefDescription = "Lifecycle aware objects should be instantiated inside a lifecycle delegate. Eg. val someObject by lifecycle(SomeObject())",
+  explanation = "All lifecycle aware objects need to be attached to a parent for listening to lifecycle.",
+  category = Category.CORRECTNESS,
+  priority = PRIORITY_HIGH,
+  severity = ERROR,
+  implementation = Implementation(EnforceLifecycleAwareAttachment::class.java, JAVA_FILE_SCOPE)
+)
+
+internal class EnforceLifecycleAwareAttachment : Detector(), Detector.UastScanner {
+
+  override fun getApplicableUastTypes() = listOf(UField::class.java)
+
+  override fun createUastHandler(context: JavaContext) = LifecycleAwareChecker(context)
+
+  class LifecycleAwareChecker(private val context: JavaContext) : UElementHandler() {
+
+    override fun visitField(node: UField) {
+      if (context.isKotlin() && node.isLifecycleAware() && node.isConstructor()) {
+        context.report(
+          ENFORCE_LIFECYCLE_AWARE_ATTACHMENT,
+          node,
+          context.getLocation(node),
+          "In order to make this lifecycle aware work as expected, " +
+            "please attach it to the lifecycle owner with a lifecycle delegate. " +
+            "Eg. val someObject by lifecycle(SomeObject()) or lateinit var someObject: SomeObject by lateinitLifecycle()"
+        )
+      }
+    }
+  }
+}
+
+private fun JavaContext.isKotlin() = file.name.endsWith("kt")
+
+private fun UField.isLifecycleAware(): Boolean {
+  return typeReference?.type?.superTypes?.any {
+    it.canonicalText == "com.wealthfront.magellan.lifecycle.LifecycleAware"
+  } ?: false
+}
+
+private fun UField.isConstructor(): Boolean {
+  return uastInitializer?.isConstructorCall() ?: false
+}

--- a/magellan-lint/src/main/java/com/wealthfront/magellan/InvalidChildInScreenContainer.kt
+++ b/magellan-lint/src/main/java/com/wealthfront/magellan/InvalidChildInScreenContainer.kt
@@ -13,7 +13,7 @@ internal val INVALID_CHILD_IN_SCREEN_CONTAINER = Issue.create(
   id = InvalidChildInScreenContainer::class.simpleName!!,
   briefDescription = "ScreenContainer should not have child declared in XML.",
   explanation = "ScreenContainers are used to inflate the view's associated with steps/journey's internally." +
-    "If you declare child views in the XML, it may result in expected results.",
+    "If you declare child views in the XML, it may result in unexpected results.",
   category = Category.CORRECTNESS,
   priority = PRIORITY_HIGH,
   severity = ERROR,

--- a/magellan-lint/src/main/java/com/wealthfront/magellan/LintRegistry.kt
+++ b/magellan-lint/src/main/java/com/wealthfront/magellan/LintRegistry.kt
@@ -11,7 +11,10 @@ internal const val PRIORITY_MAX = 10
 class LintRegistry : IssueRegistry() {
 
   override val issues: List<Issue>
-    get() = listOf(INVALID_CHILD_IN_SCREEN_CONTAINER)
+    get() = listOf(
+      INVALID_CHILD_IN_SCREEN_CONTAINER,
+      ENFORCE_LIFECYCLE_AWARE_ATTACHMENT
+    )
 
   override val api: Int
     get() = CURRENT_API

--- a/magellan-lint/src/test/java/com/wealthfront/magellan/EnforceLifecycleAwareAttachmentTest.kt
+++ b/magellan-lint/src/test/java/com/wealthfront/magellan/EnforceLifecycleAwareAttachmentTest.kt
@@ -1,0 +1,90 @@
+package com.wealthfront.magellan
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.kt
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import org.junit.Test
+
+class EnforceLifecycleAwareAttachmentTest {
+
+  private val LIFECYCLE_AWARE = kt(
+  """
+    package com.wealthfront.magellan.lifecycle
+
+    interface LifecycleAware {
+    
+      fun create() {}
+    }
+
+  """).indented()
+
+  private val LINEAR_NAVIGATOR = kt(
+    """
+    package com.wealthfront.magellan.navigation
+    
+    import com.wealthfront.magellan.lifecycle.LifecycleAware
+    
+    class LinearNavigator: LifecycleAware {
+    
+      val backStack: List<NavigationEvent> = listOf()
+    }
+  """).indented()
+
+  private val LIFECYCLE_OWNER = kt(
+    """
+      package com.wealthfront.magellan.lifecycle
+
+      interface LifecycleOwner {
+      
+        fun attachToLifecycle(lifecycleAware: LifecycleAware, detachedState: LifecycleState = LifecycleState.Destroyed)
+      
+        fun removeFromLifecycle(lifecycleAware: LifecycleAware, detachedState: LifecycleState = LifecycleState.Destroyed)
+      }
+
+  """).indented()
+
+  private val LIFECYCLE_FILES = arrayOf(LIFECYCLE_AWARE, LIFECYCLE_OWNER, LINEAR_NAVIGATOR)
+
+  @Test
+  fun testThatInstanceCreationIsDetected() {
+    lint()
+      .files(*LIFECYCLE_FILES, kt("""
+          package com.wealthfront.magellan.app
+
+          import com.wealthfront.magellan.lifecycle.LifecycleOwner
+          import com.wealthfront.magellan.navigation.LinearNavigator
+          
+          class SomeClass : LifecycleOwner {
+          
+            val navigator = LinearNavigator()
+          }
+        """).indented())
+      .issues(ENFORCE_LIFECYCLE_AWARE_ATTACHMENT)
+      .run()
+      .expect("src/com/wealthfront/magellan/app/SomeClass.kt:8: " +
+        "Error: In order to make this lifecycle aware work as expected, please attach it to the lifecycle owner with a lifecycle delegate. " +
+        "Eg. val someObject by lifecycle(SomeObject()) or lateinit var someObject: SomeObject by lateinitLifecycle() [EnforceLifecycleAwareAttachment]\n" +
+        "  val navigator = LinearNavigator()\n" +
+        "  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
+        "1 errors, 0 warnings")
+      .expectFixDiffs("")
+  }
+
+  @Test
+  fun testThatProperInstanceCreationIsNotDetected() {
+    lint()
+      .files(*LIFECYCLE_FILES, kt("""
+          package com.wealthfront.magellan.app
+
+          import com.wealthfront.magellan.lifecycle.LifecycleAware
+                    import com.wealthfront.magellan.navigation.LinearNavigator
+
+          class SomeClass : LifecycleAware {
+          
+            val navigator by lifecycle(LinearNavigator())
+          }
+        """).indented())
+      .issues(ENFORCE_LIFECYCLE_AWARE_ATTACHMENT)
+      .run()
+      .expectClean()
+  }
+}


### PR DESCRIPTION
Example: 
```
Error: In order to make this lifecycle aware work as expected, please attach it to the lifecycle owner with a lifecycle delegate.
Eg. val someObject by lifecycle(SomeObject()) or lateinit var someObject: SomeObject by lateinitLifecycle() [EnforceLifecycleAwareAttachment]

private val rxUnsubscriber = RxUnsubscriber()
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```