### PR TITLE
Add compatibility for history rewriting APIs and rename LegacyNavigator

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.wealthfront
-VERSION_NAME=2.0.0-development
+VERSION_NAME=2.0.1-alpha
 
 POM_DESCRIPTION=The simplest navigation library for Android
 

--- a/magellan-legacy/src/main/java/com/wealthfront/magellan/HistoryRewriter.java
+++ b/magellan-legacy/src/main/java/com/wealthfront/magellan/HistoryRewriter.java
@@ -1,0 +1,17 @@
+package com.wealthfront.magellan;
+
+import android.app.Activity;
+
+import com.wealthfront.magellan.navigation.NavigableCompat;
+
+import java.util.Deque;
+
+public interface HistoryRewriter {
+
+  /**
+   * Used to rewrite history on the fly, using either {@link Navigator#rewriteHistory(Activity, HistoryRewriter)} or
+   * {@link Navigator#navigate(HistoryRewriter)} (and its variants).
+   */
+  void rewriteHistory(Deque<NavigableCompat> history);
+
+}

--- a/magellan-legacy/src/main/java/com/wealthfront/magellan/HistoryRewriterExtensions.kt
+++ b/magellan-legacy/src/main/java/com/wealthfront/magellan/HistoryRewriterExtensions.kt
@@ -1,0 +1,29 @@
+import com.wealthfront.magellan.HistoryRewriter
+import com.wealthfront.magellan.NavigationType
+import com.wealthfront.magellan.navigation.NavigationEvent
+import com.wealthfront.magellan.toTransition
+import com.wealthfront.magellan.transitions.DefaultTransition
+import java.util.ArrayDeque
+import java.util.Deque
+
+internal fun HistoryRewriter.rewriteHistoryWithNavigationEvents(
+  oldBackStack: Deque<NavigationEvent>,
+  navigationType: NavigationType? = null
+) {
+  val modifiedBackStackOfScreens = ArrayDeque(oldBackStack.map { it.navigable })
+  rewriteHistory(modifiedBackStackOfScreens)
+  oldBackStack.clear()
+  modifiedBackStackOfScreens.forEach { screen ->
+    val navEvent = oldBackStack.find { it.navigable == screen }
+    if (navEvent != null) {
+      oldBackStack.add(navEvent)
+    } else {
+      oldBackStack.add(NavigationEvent(screen, DefaultTransition()))
+    }
+  }
+  if (navigationType != null) {
+    val lastNav = oldBackStack.last
+    oldBackStack.removeLast()
+    oldBackStack.add(NavigationEvent(lastNav.navigable, navigationType.toTransition()))
+  }
+}

--- a/magellan-legacy/src/main/java/com/wealthfront/magellan/LegacyExpedition.kt
+++ b/magellan-legacy/src/main/java/com/wealthfront/magellan/LegacyExpedition.kt
@@ -11,7 +11,7 @@ public abstract class LegacyExpedition<V : ViewBinding>(
   container: V.() -> ScreenContainer
 ) : Step<V>(createBinding) {
 
-  public var navigator: LegacyNavigator by lifecycle(LegacyNavigator(this) { viewBinding!!.container() })
+  public var navigator: Navigator by lifecycle(Navigator(this) { viewBinding!!.container() })
 
   public fun setMenu(menu: Menu) {
     navigator.menu = menu

--- a/magellan-legacy/src/main/java/com/wealthfront/magellan/NavigationType.kt
+++ b/magellan-legacy/src/main/java/com/wealthfront/magellan/NavigationType.kt
@@ -1,0 +1,32 @@
+package com.wealthfront.magellan
+
+import com.wealthfront.magellan.NavigationType.GO
+import com.wealthfront.magellan.NavigationType.NO_ANIM
+import com.wealthfront.magellan.NavigationType.SHOW
+import com.wealthfront.magellan.transitions.DefaultTransition
+import com.wealthfront.magellan.transitions.MagellanTransition
+import com.wealthfront.magellan.transitions.NoAnimationTransition
+import com.wealthfront.magellan.transitions.ShowTransition
+
+/**
+ * Represents the different types of navigation we support:
+ *
+ *  * SHOW: represent a modal type of Navigation, where the Screen is only shown if not already displayed, and
+ * with a default animation of sliding the new screen from the bottom.
+ *  * GO: is the normal type of navigation, with a default animation of sliding both screens in sync from the right
+ * to the left.
+ *  * NO_ANIM: represent a normal navigation but with no animation.
+ *
+ */
+public enum class NavigationType {
+
+  SHOW, GO, NO_ANIM
+}
+
+internal fun NavigationType.toTransition(): MagellanTransition {
+  return when (this) {
+    GO -> DefaultTransition()
+    SHOW -> ShowTransition()
+    NO_ANIM -> NoAnimationTransition()
+  }
+}

--- a/magellan-legacy/src/main/java/com/wealthfront/magellan/Navigator.kt
+++ b/magellan-legacy/src/main/java/com/wealthfront/magellan/Navigator.kt
@@ -1,5 +1,6 @@
 package com.wealthfront.magellan
 
+import android.app.Activity
 import android.view.Menu
 import com.wealthfront.magellan.Direction.BACKWARD
 import com.wealthfront.magellan.Direction.FORWARD
@@ -14,17 +15,17 @@ import com.wealthfront.magellan.transitions.DefaultTransition
 import com.wealthfront.magellan.transitions.MagellanTransition
 import com.wealthfront.magellan.transitions.NoAnimationTransition
 import com.wealthfront.magellan.transitions.ShowTransition
-import java.lang.IllegalStateException
-import java.util.Stack
+import rewriteHistoryWithNavigationEvents
+import java.util.Deque
 
-public class LegacyNavigator internal constructor(
+public class Navigator internal constructor(
   override val journey: Step<*>,
   container: () -> ScreenContainer
 ) : Navigator, LifecycleAwareComponent() {
 
   private val delegate by lifecycle(NavigationDelegate(journey, container))
 
-  override val backStack: Stack<NavigationEvent>
+  override val backStack: Deque<NavigationEvent>
     get() = delegate.backStack
 
   internal var menu: Menu? = null
@@ -44,19 +45,19 @@ public class LegacyNavigator internal constructor(
     }
   }
 
-  public fun navigate(backStackOperation: (Stack<NavigationEvent>) -> NavigationEvent) {
+  public fun navigate(backStackOperation: (Deque<NavigationEvent>) -> NavigationEvent) {
     navigate(FORWARD, backStackOperation)
   }
 
   public fun navigate(
     direction: Direction,
-    backStackOperation: (Stack<NavigationEvent>) -> NavigationEvent
+    backStackOperation: (Deque<NavigationEvent>) -> NavigationEvent
   ) {
     delegate.navigate(direction, backStackOperation)
   }
 
-  public fun replace(navigable: NavigableCompat) {
-    delegate.replace(navigable)
+  public fun replace(navigable: NavigableCompat, magellanTransition: MagellanTransition? = null) {
+    delegate.replace(navigable, magellanTransition)
   }
 
   public fun replaceNow(navigable: NavigableCompat) {
@@ -80,7 +81,10 @@ public class LegacyNavigator internal constructor(
   }
 
   @JvmOverloads
-  public fun hide(navigable: NavigableCompat, overrideMagellanTransition: MagellanTransition? = null) {
+  public fun hide(
+    navigable: NavigableCompat,
+    overrideMagellanTransition: MagellanTransition? = null
+  ) {
     navigate(BACKWARD) { backStack ->
       val backStackItem = backStack.find { it.navigable == navigable }
         ?: throw IllegalStateException("Cannot find navigable (${navigable::class.java.simpleName}) in the backstack!")
@@ -107,5 +111,35 @@ public class LegacyNavigator internal constructor(
 
   public fun goBack(): Boolean {
     return delegate.goBack()
+  }
+
+  public fun rewriteHistory(activity: Activity?, historyRewriter: HistoryRewriter) {
+    checkNotNull(activity != null) { "Activity cannot be null" }
+    navigate(historyRewriter)
+  }
+
+  public fun navigate(historyRewriter: HistoryRewriter) {
+    navigate(FORWARD) { backStack ->
+      historyRewriter.rewriteHistoryWithNavigationEvents(backStack)
+      backStack.peek()!!
+    }
+  }
+
+  public fun navigate(historyRewriter: HistoryRewriter, navType: NavigationType) {
+    navigate(FORWARD) { backStack ->
+      historyRewriter.rewriteHistoryWithNavigationEvents(backStack, navType)
+      backStack.peek()!!
+    }
+  }
+
+  public fun navigate(
+    historyRewriter: HistoryRewriter,
+    navType: NavigationType,
+    direction: Direction
+  ) {
+    navigate(direction) { backStack ->
+      historyRewriter.rewriteHistoryWithNavigationEvents(backStack, navType)
+      backStack.peek()!!
+    }
   }
 }

--- a/magellan-legacy/src/main/java/com/wealthfront/magellan/Screen.java
+++ b/magellan-legacy/src/main/java/com/wealthfront/magellan/Screen.java
@@ -45,7 +45,7 @@ public abstract class Screen<V extends ViewGroup & ScreenView> extends Lifecycle
   private @Nullable V view;
   private boolean isTransitioning;
   private final Queue<TransitionFinishedListener> transitionFinishedListeners = new LinkedList<>();
-  private LegacyNavigator navigator;
+  private Navigator navigator;
 
   public Screen() {
     attachToLifecycle(new LegacyViewComponent<>(this));
@@ -74,7 +74,7 @@ public abstract class Screen<V extends ViewGroup & ScreenView> extends Lifecycle
    * @return the Navigator associated with this Screen.
    */
   @NotNull
-  public final LegacyNavigator getNavigator() {
+  public final Navigator getNavigator() {
     return navigator;
   }
 
@@ -197,7 +197,7 @@ public abstract class Screen<V extends ViewGroup & ScreenView> extends Lifecycle
     this.activity = activity;
   }
 
-  void setNavigator(@NotNull LegacyNavigator navigator) {
+  void setNavigator(@NotNull Navigator navigator) {
     this.navigator = navigator;
   }
 

--- a/magellan-legacy/src/test/java/com/wealthfront/magellan/HistoryRewriterExtensionsKtTest.kt
+++ b/magellan-legacy/src/test/java/com/wealthfront/magellan/HistoryRewriterExtensionsKtTest.kt
@@ -1,0 +1,107 @@
+package com.wealthfront.magellan
+
+import com.google.common.truth.Truth.assertThat
+import com.wealthfront.magellan.core.Journey
+import com.wealthfront.magellan.databinding.MagellanDummyLayoutBinding
+import com.wealthfront.magellan.navigation.NavigationEvent
+import com.wealthfront.magellan.transitions.DefaultTransition
+import com.wealthfront.magellan.transitions.ShowTransition
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations.initMocks
+import rewriteHistoryWithNavigationEvents
+import java.util.ArrayDeque
+
+public class HistoryRewriterExtensionsKtTest {
+
+  private lateinit var root: LegacyExpedition<*>
+  private lateinit var journey1: Journey<*>
+  private lateinit var screen: Screen<*>
+  @Mock private lateinit var view: BaseScreenView<DummyScreen>
+
+  @Before
+  public fun setUp() {
+    initMocks(this)
+    root = RootJourney()
+    journey1 = DummyJourney1()
+    screen = DummyScreen(view)
+  }
+
+  @Test
+  public fun historyRewriter() {
+    val backStack = ArrayDeque<NavigationEvent>()
+    backStack.push(NavigationEvent(root, DefaultTransition()))
+    backStack.push(NavigationEvent(journey1, ShowTransition()))
+    backStack.push(NavigationEvent(screen, DefaultTransition()))
+
+    val historyRewriter = HistoryRewriter { stack ->
+      stack.pop()
+    }
+
+    assertThat(backStack.size).isEqualTo(3)
+
+    historyRewriter.rewriteHistoryWithNavigationEvents(backStack)
+
+    assertThat(backStack.size).isEqualTo(2)
+
+    val journeyInBackStack = backStack.poll()!!
+    val rootInBackStack = backStack.poll()!!
+
+    assertThat(journeyInBackStack.navigable).isEqualTo(journey1)
+    assertThat(journeyInBackStack.magellanTransition).isInstanceOf(DefaultTransition::class.java)
+    assertThat(rootInBackStack.navigable).isEqualTo(root)
+    assertThat(rootInBackStack.magellanTransition).isInstanceOf(DefaultTransition::class.java)
+  }
+
+  @Test
+  public fun historyRewriter_compatibility() {
+    val backStack = ArrayDeque<NavigationEvent>()
+    backStack.push(NavigationEvent(root, DefaultTransition()))
+    backStack.push(NavigationEvent(journey1, ShowTransition()))
+
+    val historyRewriter = HistoryRewriter { stack ->
+      stack.push(screen)
+    }
+
+    assertThat(backStack.size).isEqualTo(2)
+
+    historyRewriter.rewriteHistoryWithNavigationEvents(backStack)
+
+    assertThat(backStack.size).isEqualTo(3)
+
+    val screenInBackStack = backStack.poll()!!
+    val journeyInBackStack = backStack.poll()!!
+    val rootInBackStack = backStack.poll()!!
+
+    assertThat(screenInBackStack.navigable).isEqualTo(screen)
+    assertThat(screenInBackStack.magellanTransition).isInstanceOf(DefaultTransition::class.java)
+    assertThat(journeyInBackStack.navigable).isEqualTo(journey1)
+    assertThat(journeyInBackStack.magellanTransition).isInstanceOf(DefaultTransition::class.java)
+    assertThat(rootInBackStack.navigable).isEqualTo(root)
+    assertThat(rootInBackStack.magellanTransition).isInstanceOf(DefaultTransition::class.java)
+  }
+
+  @Test(expected = NoSuchElementException::class)
+  public fun historyRewriter_exceptionWhenNoItemOnBackStack() {
+    val backStack = ArrayDeque<NavigationEvent>()
+    backStack.push(NavigationEvent(root, DefaultTransition()))
+
+    val historyRewriter = HistoryRewriter { stack ->
+      stack.pop()
+      stack.pop()
+    }
+
+    historyRewriter.rewriteHistoryWithNavigationEvents(backStack)
+  }
+
+  private inner class RootJourney : LegacyExpedition<MagellanDummyLayoutBinding>(
+    MagellanDummyLayoutBinding::inflate,
+    MagellanDummyLayoutBinding::container
+  )
+
+  private inner class DummyJourney1 : Journey<MagellanDummyLayoutBinding>(
+    MagellanDummyLayoutBinding::inflate,
+    MagellanDummyLayoutBinding::container
+  )
+}

--- a/magellan-library/src/main/java/com/wealthfront/magellan/ScreenContainer.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/ScreenContainer.java
@@ -6,7 +6,7 @@ import android.view.MotionEvent;
 import android.widget.FrameLayout;
 
 /**
- * The container to be used to display the screens using the {@link Navigator}. Must have the id
+ * The container to be used to display the screens using the {@link com.wealthfront.magellan.navigation.Navigator}. Must have the id
  * {@code magellan_container}. This will also block touch events automatically during navigation to avoid accidental
  * double taps.
  */

--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/LinearNavigator.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/LinearNavigator.kt
@@ -8,7 +8,7 @@ import com.wealthfront.magellan.core.Navigable
 import com.wealthfront.magellan.lifecycle.LifecycleAwareComponent
 import com.wealthfront.magellan.lifecycle.lifecycle
 import com.wealthfront.magellan.transitions.MagellanTransition
-import java.util.Stack
+import java.util.Deque
 
 public class LinearNavigator internal constructor(
   override val journey: Journey<*>,
@@ -17,7 +17,7 @@ public class LinearNavigator internal constructor(
 
   private val delegate by lifecycle(NavigationDelegate(journey, container))
 
-  override val backStack: Stack<NavigationEvent>
+  override val backStack: Deque<NavigationEvent>
     get() = delegate.backStack
 
   internal var menu: Menu? = null
@@ -36,7 +36,7 @@ public class LinearNavigator internal constructor(
 
   public fun navigate(
     direction: Direction,
-    backStackOperation: (Stack<NavigationEvent>) -> NavigationEvent
+    backStackOperation: (Deque<NavigationEvent>) -> NavigationEvent
   ) {
     delegate.navigate(direction, backStackOperation)
   }

--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationDelegate.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationDelegate.kt
@@ -19,7 +19,8 @@ import com.wealthfront.magellan.transitions.MagellanTransition
 import com.wealthfront.magellan.view.ActionBarConfig
 import com.wealthfront.magellan.view.ActionBarModifier
 import com.wealthfront.magellan.view.whenMeasured
-import java.util.Stack
+import java.util.ArrayDeque
+import java.util.Deque
 
 public class NavigationDelegate(
   private val rootNavigable: NavigableCompat,
@@ -35,7 +36,7 @@ public class NavigationDelegate(
       updateMenu(menu)
     }
 
-  public val backStack: Stack<NavigationEvent> = Stack()
+  public val backStack: Deque<NavigationEvent> = ArrayDeque()
   public var currentNavigableSetup: ((NavigableCompat) -> Unit)? = null
 
   private val currentNavigable: NavigableCompat?
@@ -80,6 +81,7 @@ public class NavigationDelegate(
           overrideMagellanTransition ?: DefaultTransition()
         )
       )
+      backStack.peek()!!
     }
   }
 
@@ -95,6 +97,7 @@ public class NavigationDelegate(
           overrideMagellanTransition ?: DefaultTransition()
         )
       )
+      backStack.peek()!!
     }
   }
 
@@ -106,7 +109,7 @@ public class NavigationDelegate(
 
   public fun navigate(
     direction: Direction,
-    backStackOperation: (Stack<NavigationEvent>) -> NavigationEvent
+    backStackOperation: (Deque<NavigationEvent>) -> NavigationEvent
   ) {
     containerView?.setInterceptTouchEvents(true)
     val from = hideCurrentNavigable(direction)

--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationEvent.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationEvent.kt
@@ -1,13 +1,13 @@
 package com.wealthfront.magellan.navigation
 
 import com.wealthfront.magellan.transitions.MagellanTransition
-import java.util.Stack
+import java.util.Deque
 
 public data class NavigationEvent(
   val navigable: NavigableCompat,
   val magellanTransition: MagellanTransition
 )
 
-internal fun Stack<NavigationEvent>.navigables(): List<NavigableCompat> {
+internal fun Deque<NavigationEvent>.navigables(): List<NavigableCompat> {
   return map { it.navigable }
 }

--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationTraverser.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationTraverser.kt
@@ -2,6 +2,7 @@ package com.wealthfront.magellan.navigation
 
 import android.util.Log
 import com.wealthfront.magellan.lifecycle.LifecycleOwner
+import java.util.Deque
 
 public class NavigationTraverser(private val root: NavigableCompat) {
 
@@ -12,8 +13,9 @@ public class NavigationTraverser(private val root: NavigableCompat) {
   private fun constructTree(navigable: NavigableCompat): NavigationNode {
     val navNode = NavigationNode(navigable, mutableListOf())
     if (navNode.hasBackstack) {
-      navNode.backStack.forEach { navEvent ->
-        val childNavNode = constructTree(navEvent.navigable)
+      while (navNode.backStack.isNotEmpty()) {
+        val node = navNode.backStack.removeLast()
+        val childNavNode = constructTree(node.navigable)
         navNode.addChild(childNavNode)
       }
     }
@@ -52,7 +54,7 @@ public data class NavigationNode(
     get() = (value as? LifecycleOwner)?.children?.mapNotNull { it as? Navigator }?.isNotEmpty()
       ?: false
 
-  val backStack: List<NavigationEvent>
+  val backStack: Deque<NavigationEvent>
     get() = (value as LifecycleOwner).children.mapNotNull { it as? Navigator }.first().backStack
 
   public fun addChild(child: NavigationNode) {

--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/Navigator.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/Navigator.kt
@@ -1,8 +1,10 @@
 package com.wealthfront.magellan.navigation
 
+import java.util.Deque
+
 public interface Navigator {
 
   public val journey: NavigableCompat
 
-  public val backStack: List<NavigationEvent>
+  public val backStack: Deque<NavigationEvent>
 }

--- a/magellan-library/src/test/java/com/wealthfront/magellan/navigation/LinearNavigatorTest.kt
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/navigation/LinearNavigatorTest.kt
@@ -77,8 +77,8 @@ class LinearNavigatorTest {
     verify(step1 as ActionBarModifier).onUpdateMenu(menu)
     verify(context as ActionBarConfigListener).onNavigate(any())
     assertThat(linearNavigator.backStack.size).isEqualTo(1)
-    assertThat(linearNavigator.backStack.peek().navigable).isEqualTo(step1)
-    assertThat(linearNavigator.backStack.peek().magellanTransition.javaClass).isEqualTo(DefaultTransition::class.java)
+    assertThat(linearNavigator.backStack.peek()!!.navigable).isEqualTo(step1)
+    assertThat(linearNavigator.backStack.peek()!!.magellanTransition.javaClass).isEqualTo(DefaultTransition::class.java)
   }
 
   @Test
@@ -86,8 +86,8 @@ class LinearNavigatorTest {
     linearNavigator.goTo(step1, ShowTransition())
 
     assertThat(linearNavigator.backStack.size).isEqualTo(1)
-    assertThat(linearNavigator.backStack.peek().navigable).isEqualTo(step1)
-    assertThat(linearNavigator.backStack.peek().magellanTransition.javaClass).isEqualTo(ShowTransition::class.java)
+    assertThat(linearNavigator.backStack.peek()!!.navigable).isEqualTo(step1)
+    assertThat(linearNavigator.backStack.peek()!!.magellanTransition.javaClass).isEqualTo(ShowTransition::class.java)
   }
 
   @Test
@@ -96,8 +96,8 @@ class LinearNavigatorTest {
     linearNavigator.replace(step2)
 
     assertThat(linearNavigator.backStack.size).isEqualTo(1)
-    assertThat(linearNavigator.backStack.peek().navigable).isEqualTo(step2)
-    assertThat(linearNavigator.backStack.peek().magellanTransition.javaClass).isEqualTo(DefaultTransition::class.java)
+    assertThat(linearNavigator.backStack.peek()!!.navigable).isEqualTo(step2)
+    assertThat(linearNavigator.backStack.peek()!!.magellanTransition.javaClass).isEqualTo(DefaultTransition::class.java)
   }
 
   @Test
@@ -106,8 +106,8 @@ class LinearNavigatorTest {
     linearNavigator.replace(step2, ShowTransition())
 
     assertThat(linearNavigator.backStack.size).isEqualTo(1)
-    assertThat(linearNavigator.backStack.peek().navigable).isEqualTo(step2)
-    assertThat(linearNavigator.backStack.peek().magellanTransition.javaClass).isEqualTo(ShowTransition::class.java)
+    assertThat(linearNavigator.backStack.peek()!!.navigable).isEqualTo(step2)
+    assertThat(linearNavigator.backStack.peek()!!.magellanTransition.javaClass).isEqualTo(ShowTransition::class.java)
   }
 
   @Test
@@ -118,8 +118,8 @@ class LinearNavigatorTest {
 
     assertThat(didNavigate).isTrue()
     assertThat(linearNavigator.backStack.size).isEqualTo(1)
-    assertThat(linearNavigator.backStack.peek().navigable).isEqualTo(step1)
-    assertThat(linearNavigator.backStack.peek().magellanTransition.javaClass).isEqualTo(DefaultTransition::class.java)
+    assertThat(linearNavigator.backStack.peek()!!.navigable).isEqualTo(step1)
+    assertThat(linearNavigator.backStack.peek()!!.magellanTransition.javaClass).isEqualTo(DefaultTransition::class.java)
   }
 
   @Test
@@ -129,8 +129,8 @@ class LinearNavigatorTest {
 
     assertThat(didNavigate).isFalse()
     assertThat(linearNavigator.backStack.size).isEqualTo(1)
-    assertThat(linearNavigator.backStack.peek().navigable).isEqualTo(step1)
-    assertThat(linearNavigator.backStack.peek().magellanTransition.javaClass).isEqualTo(DefaultTransition::class.java)
+    assertThat(linearNavigator.backStack.peek()!!.navigable).isEqualTo(step1)
+    assertThat(linearNavigator.backStack.peek()!!.magellanTransition.javaClass).isEqualTo(DefaultTransition::class.java)
   }
 
   @Test
@@ -141,14 +141,15 @@ class LinearNavigatorTest {
       it.push(NavigationEvent(step1, DefaultTransition()))
       it.push(NavigationEvent(step2, DefaultTransition()))
       it.push(NavigationEvent(journey1, ShowTransition()))
+      it.peek()!!
     }
 
     val didNavigate = linearNavigator.goBack()
 
     assertThat(didNavigate).isTrue()
     assertThat(linearNavigator.backStack.size).isEqualTo(2)
-    assertThat(linearNavigator.backStack.peek().navigable).isEqualTo(step2)
-    assertThat(linearNavigator.backStack.peek().magellanTransition.javaClass).isEqualTo(DefaultTransition::class.java)
+    assertThat(linearNavigator.backStack.peek()!!.navigable).isEqualTo(step2)
+    assertThat(linearNavigator.backStack.peek()!!.magellanTransition.javaClass).isEqualTo(DefaultTransition::class.java)
   }
 
   @Test
@@ -159,6 +160,7 @@ class LinearNavigatorTest {
       it.push(NavigationEvent(step1, DefaultTransition()))
       it.push(NavigationEvent(step2, DefaultTransition()))
       it.push(NavigationEvent(journey1, ShowTransition()))
+      it.peek()!!
     }
 
     linearNavigator.goBack()
@@ -173,6 +175,7 @@ class LinearNavigatorTest {
   fun goBack_backOutOfJourney() {
     linearNavigator.navigate(FORWARD) {
       it.push(NavigationEvent(journey1, ShowTransition()))
+      it.peek()!!
     }
 
     val didNavigate = linearNavigator.goBack()


### PR DESCRIPTION
This PR adds better backwards compatibility support for the HistoryRewriter APIs. This should make the migration simpler and support the old use cases better.