### PR TITLE
Fix navigation delegate

### DIFF
--- a/magellan-library/src/main/java/com/wealthfront/magellan/Direction.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/Direction.kt
@@ -5,7 +5,7 @@ package com.wealthfront.magellan
  */
 public enum class Direction(private val sign: Int) {
 
-  FORWARD(1), NO_MOVEMENT(0), BACKWARD(-1);
+  FORWARD(1), BACKWARD(-1);
 
   internal fun sign(): Int {
     return sign

--- a/magellan-library/src/main/java/com/wealthfront/magellan/debug/StatePrinter.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/debug/StatePrinter.kt
@@ -42,7 +42,7 @@ private fun LifecycleAware.getLifecycleStateSnapshotRecursive(
           "$VERTICAL_LINE$INDENT_SPACE"
         }
         lifecycleAware.getLifecycleStateSnapshotRecursive(
-          indent + childIndent,
+          childIndent,
           index == children.lastIndex,
           currentState
         )

--- a/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleAwareComponent.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleAwareComponent.kt
@@ -15,7 +15,8 @@ public abstract class LifecycleAwareComponent : LifecycleAware, LifecycleOwner {
   final override fun create(context: Context) {
     if (currentState !is LifecycleState.Destroyed) {
       throw IllegalStateException(
-        "Cannot create() from a state that is not Destroyed: ${currentState::class.java.simpleName}"
+        "Cannot create() from a state that is not Destroyed: " +
+          "${this::class.java.simpleName} is ${currentState::class.java.simpleName}"
       )
     }
     lifecycleRegistry.create(context)
@@ -25,7 +26,8 @@ public abstract class LifecycleAwareComponent : LifecycleAware, LifecycleOwner {
   final override fun show(context: Context) {
     if (currentState !is LifecycleState.Created) {
       throw IllegalStateException(
-        "Cannot show() from a state that is not Created: ${currentState::class.java.simpleName}"
+        "Cannot show() from a state that is not Created: " +
+          "${this::class.java.simpleName} is ${currentState::class.java.simpleName}"
       )
     }
     lifecycleRegistry.show(context)
@@ -35,7 +37,8 @@ public abstract class LifecycleAwareComponent : LifecycleAware, LifecycleOwner {
   final override fun resume(context: Context) {
     if (currentState !is LifecycleState.Shown) {
       throw IllegalStateException(
-        "Cannot resume() from a state that is not Shown: ${currentState::class.java.simpleName}"
+        "Cannot resume() from a state that is not Shown: " +
+          "${this::class.java.simpleName} is ${currentState::class.java.simpleName}"
       )
     }
     lifecycleRegistry.resume(context)
@@ -45,7 +48,8 @@ public abstract class LifecycleAwareComponent : LifecycleAware, LifecycleOwner {
   final override fun pause(context: Context) {
     if (currentState !is LifecycleState.Resumed) {
       throw IllegalStateException(
-        "Cannot pause() from a state that is not Resumed: ${currentState::class.java.simpleName}"
+        "Cannot pause() from a state that is not Resumed: " +
+          "${this::class.java.simpleName} is ${currentState::class.java.simpleName}"
       )
     }
     onPause(context)
@@ -55,7 +59,8 @@ public abstract class LifecycleAwareComponent : LifecycleAware, LifecycleOwner {
   final override fun hide(context: Context) {
     if (currentState !is LifecycleState.Shown) {
       throw IllegalStateException(
-        "Cannot hide() from a state that is not Shown: ${currentState::class.java.simpleName}"
+        "Cannot hide() from a state that is not Shown: " +
+          "${this::class.java.simpleName} is ${currentState::class.java.simpleName}"
       )
     }
     onHide(context)
@@ -65,7 +70,8 @@ public abstract class LifecycleAwareComponent : LifecycleAware, LifecycleOwner {
   final override fun destroy(context: Context) {
     if (currentState !is LifecycleState.Created) {
       throw IllegalStateException(
-        "Cannot destroy() from a state that is not Created: ${currentState::class.java.simpleName}"
+        "Cannot destroy() from a state that is not Created: " +
+          "${this::class.java.simpleName} is ${currentState::class.java.simpleName}"
       )
     }
     onDestroy(context)

--- a/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleAwareComponent.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleAwareComponent.kt
@@ -13,31 +13,61 @@ public abstract class LifecycleAwareComponent : LifecycleAware, LifecycleOwner {
     get() = lifecycleRegistry.currentState
 
   final override fun create(context: Context) {
+    if (currentState !is LifecycleState.Destroyed) {
+      throw IllegalStateException(
+        "Cannot create() from a state that is not Destroyed: ${currentState::class.java.simpleName}"
+      )
+    }
     lifecycleRegistry.create(context)
     onCreate(context)
   }
 
   final override fun show(context: Context) {
+    if (currentState !is LifecycleState.Created) {
+      throw IllegalStateException(
+        "Cannot show() from a state that is not Created: ${currentState::class.java.simpleName}"
+      )
+    }
     lifecycleRegistry.show(context)
     onShow(context)
   }
 
   final override fun resume(context: Context) {
+    if (currentState !is LifecycleState.Shown) {
+      throw IllegalStateException(
+        "Cannot resume() from a state that is not Shown: ${currentState::class.java.simpleName}"
+      )
+    }
     lifecycleRegistry.resume(context)
     onResume(context)
   }
 
   final override fun pause(context: Context) {
+    if (currentState !is LifecycleState.Resumed) {
+      throw IllegalStateException(
+        "Cannot pause() from a state that is not Resumed: ${currentState::class.java.simpleName}"
+      )
+    }
     onPause(context)
     lifecycleRegistry.pause(context)
   }
 
   final override fun hide(context: Context) {
+    if (currentState !is LifecycleState.Shown) {
+      throw IllegalStateException(
+        "Cannot hide() from a state that is not Shown: ${currentState::class.java.simpleName}"
+      )
+    }
     onHide(context)
     lifecycleRegistry.hide(context)
   }
 
   final override fun destroy(context: Context) {
+    if (currentState !is LifecycleState.Created) {
+      throw IllegalStateException(
+        "Cannot destroy() from a state that is not Created: ${currentState::class.java.simpleName}"
+      )
+    }
     onDestroy(context)
     lifecycleRegistry.destroy(context)
   }

--- a/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleRegistry.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleRegistry.kt
@@ -46,8 +46,9 @@ internal class LifecycleRegistry : LifecycleAware {
           lifecycleAware::class.java.simpleName
       )
     }
+    val maxState = listenersToMaxStates[lifecycleAware]!!
     listenersToMaxStates = listenersToMaxStates - lifecycleAware
-    lifecycleStateMachine.transition(lifecycleAware, currentState, detachedState)
+    lifecycleStateMachine.transition(lifecycleAware, currentState.limitBy(maxState), detachedState)
   }
 
   fun updateMaxState(lifecycleAware: LifecycleAware, maxState: LifecycleLimit) {

--- a/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleRegistry.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleRegistry.kt
@@ -26,6 +26,12 @@ internal class LifecycleRegistry : LifecycleAware {
     detachedState: LifecycleState = LifecycleState.Destroyed,
     maxState: LifecycleLimit = LifecycleLimit.NO_LIMIT
   ) {
+    if (listenersToMaxStates.containsKey(lifecycleAware)) {
+      throw IllegalStateException(
+        "Cannot attach a lifecycleAware that is already a child: " +
+          lifecycleAware::class.java.simpleName
+      )
+    }
     lifecycleStateMachine.transition(lifecycleAware, detachedState, currentState.limitBy(maxState))
     listenersToMaxStates = listenersToMaxStates + (lifecycleAware to maxState)
   }
@@ -34,6 +40,12 @@ internal class LifecycleRegistry : LifecycleAware {
     lifecycleAware: LifecycleAware,
     detachedState: LifecycleState = LifecycleState.Destroyed
   ) {
+    if (!listenersToMaxStates.containsKey(lifecycleAware)) {
+      throw IllegalStateException(
+        "Cannot remove a lifecycleAware that is not a child: " +
+          lifecycleAware::class.java.simpleName
+      )
+    }
     listenersToMaxStates = listenersToMaxStates - lifecycleAware
     lifecycleStateMachine.transition(lifecycleAware, currentState, detachedState)
   }

--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationDelegate.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationDelegate.kt
@@ -10,8 +10,12 @@ import com.wealthfront.magellan.ScreenContainer
 import com.wealthfront.magellan.init.getDefaultTransition
 import com.wealthfront.magellan.init.shouldRunAnimations
 import com.wealthfront.magellan.lifecycle.LifecycleAwareComponent
+import com.wealthfront.magellan.lifecycle.LifecycleLimit.CREATED
+import com.wealthfront.magellan.lifecycle.LifecycleLimit.NO_LIMIT
+import com.wealthfront.magellan.lifecycle.LifecycleLimiter
 import com.wealthfront.magellan.lifecycle.LifecycleState
 import com.wealthfront.magellan.lifecycle.LifecycleState.Created
+import com.wealthfront.magellan.lifecycle.lifecycle
 import com.wealthfront.magellan.transitions.MagellanTransition
 import com.wealthfront.magellan.transitions.NoAnimationTransition
 import com.wealthfront.magellan.view.whenMeasured
@@ -27,6 +31,8 @@ public class NavigationDelegate(
   private var containerView: ScreenContainer? = null
   private val navigationPropagator = NavigationPropagator
   public val backStack: Deque<NavigationEvent> = ArrayDeque()
+
+  private val lifecycleLimiter by lifecycle(LifecycleLimiter())
 
   private val currentNavigable: NavigableCompat?
     get() {
@@ -97,10 +103,28 @@ public class NavigationDelegate(
     containerView?.setInterceptTouchEvents(true)
     navigationPropagator.beforeNavigation()
     val from = navigateFrom(currentNavigable, direction)
+    val oldBackStack = backStack.map { it.navigable }
     val transition = backStackOperation.invoke(backStack).magellanTransition
+    diffBackstackAndUpdateMaxStates(oldBackStack = oldBackStack, newBackStack = backStack.map { it.navigable })
     val to = navigateTo(currentNavigable!!, direction)
     navigationPropagator.afterNavigation()
     animateAndRemove(from, to, direction, transition)
+  }
+
+  private fun diffBackstackAndUpdateMaxStates(
+    oldBackStack: List<NavigableCompat>,
+    newBackStack: List<NavigableCompat>
+  ) {
+    val oldNavigables = oldBackStack.toSet()
+    val newNavigables = newBackStack.toSet()
+
+    (oldNavigables - newNavigables).forEach { oldNavigable ->
+      lifecycleLimiter.removeFromLifecycle(oldNavigable)
+    }
+
+    (newNavigables - oldNavigables).forEach { newNavigable ->
+      lifecycleLimiter.attachToLifecycleWithMaxState(newNavigable, CREATED)
+    }
   }
 
   private fun animateAndRemove(
@@ -128,13 +152,10 @@ public class NavigationDelegate(
 
   private fun navigateTo(currentNavigable: NavigableCompat, direction: Direction): View? {
     currentNavigableSetup?.invoke(currentNavigable)
-    attachToLifecycle(
-      currentNavigable,
-      detachedState = when (direction) {
-        FORWARD -> LifecycleState.Destroyed
-        NO_MOVEMENT, BACKWARD -> currentState.getEarlierOfCurrentState()
-      }
-    )
+    when (direction) {
+      FORWARD -> lifecycleLimiter.attachToLifecycle(currentNavigable)
+      NO_MOVEMENT, BACKWARD -> lifecycleLimiter.updateMaxStateForChild(currentNavigable, NO_LIMIT)
+    }
     navigationPropagator.onNavigatedTo(currentNavigable)
     when (currentState) {
       is LifecycleState.Shown, is LifecycleState.Resumed -> {
@@ -152,13 +173,10 @@ public class NavigationDelegate(
   private fun navigateFrom(currentNavigable: NavigableCompat?, direction: Direction): View? {
     return currentNavigable?.let { navigable ->
       val currentView = navigable.view
-      removeFromLifecycle(
-        navigable,
-        detachedState = when (direction) {
-          NO_MOVEMENT, FORWARD -> currentState.getEarlierOfCurrentState()
-          BACKWARD -> LifecycleState.Destroyed
-        }
-      )
+      when (direction) {
+        NO_MOVEMENT, FORWARD -> lifecycleLimiter.updateMaxStateForChild(navigable, CREATED)
+        BACKWARD -> lifecycleLimiter.removeFromLifecycle(navigable)
+      }
       navigationPropagator.onNavigatedFrom(navigable)
       currentView
     }
@@ -174,8 +192,11 @@ public class NavigationDelegate(
   }
 
   public fun resetWithRoot(navigable: NavigableCompat) {
-    backStack.clear()
-    backStack.push(NavigationEvent(navigable, NoAnimationTransition()))
+    navigate(FORWARD) { backStack ->
+      backStack.clear()
+      backStack.push(NavigationEvent(navigable, NoAnimationTransition()))
+      backStack.peek()!!
+    }
   }
 
   override fun onBackPressed(): Boolean = currentNavigable?.backPressed() ?: false || goBack()

--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationDelegate.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationDelegate.kt
@@ -104,13 +104,14 @@ public class NavigationDelegate(
     val from = navigateFrom(currentNavigable)
     val oldBackStack = backStack.map { it.navigable }
     val transition = backStackOperation.invoke(backStack).magellanTransition
-    diffBackstackAndUpdateMaxStates(oldBackStack = oldBackStack, newBackStack = backStack.map { it.navigable })
+    val newBackStack = backStack.map { it.navigable }
+    findBackstackChangesAndUpdateStates(oldBackStack = oldBackStack, newBackStack = newBackStack)
     val to = navigateTo(currentNavigable!!, direction)
     navigationPropagator.afterNavigation()
     animateAndRemove(from, to, direction, transition)
   }
 
-  private fun diffBackstackAndUpdateMaxStates(
+  private fun findBackstackChangesAndUpdateStates(
     oldBackStack: List<NavigableCompat>,
     newBackStack: List<NavigableCompat>
   ) {

--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationDelegate.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationDelegate.kt
@@ -101,7 +101,7 @@ public class NavigationDelegate(
   ) {
     containerView?.setInterceptTouchEvents(true)
     navigationPropagator.beforeNavigation()
-    val from = navigateFrom(currentNavigable, direction)
+    val from = navigateFrom(currentNavigable)
     val oldBackStack = backStack.map { it.navigable }
     val transition = backStackOperation.invoke(backStack).magellanTransition
     diffBackstackAndUpdateMaxStates(oldBackStack = oldBackStack, newBackStack = backStack.map { it.navigable })
@@ -166,13 +166,10 @@ public class NavigationDelegate(
     return currentNavigable.view
   }
 
-  private fun navigateFrom(currentNavigable: NavigableCompat?, direction: Direction): View? {
+  private fun navigateFrom(currentNavigable: NavigableCompat?): View? {
     return currentNavigable?.let { oldNavigable ->
       val currentView = oldNavigable.view
-      when (direction) {
-        FORWARD -> lifecycleLimiter.updateMaxStateForChild(oldNavigable, CREATED)
-        BACKWARD -> lifecycleLimiter.removeFromLifecycle(oldNavigable)
-      }
+      lifecycleLimiter.updateMaxStateForChild(oldNavigable, CREATED)
       navigationPropagator.onNavigatedFrom(oldNavigable)
       currentView
     }

--- a/magellan-library/src/test/java/com/wealthfront/magellan/debug/StatePrinterTest.kt
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/debug/StatePrinterTest.kt
@@ -54,7 +54,9 @@ public class StatePrinterTest {
   @Test
   public fun complexTree() {
     root.attachToLifecycle(MyStep())
-    root.attachToLifecycle(MyJourney().apply { attachToLifecycle(MyStep()) })
+    val step = MyStep()
+    root.attachToLifecycle(MyJourney().apply { attachToLifecycle(step) })
+    step.attachToLifecycle(MySection())
     root.attachToLifecycle(MyJourney().apply { attachToLifecycle(MyLifecycleAwareThing()) })
     root.create(context)
     assertThat(root.getLifecycleStateSnapshot()).isEqualTo(
@@ -63,6 +65,7 @@ public class StatePrinterTest {
         ├ MyStep (Created)
         ├ MyJourney (Created)
         | └ MyStep (Created)
+        |   └ MySection (Created)
         └ MyJourney (Created)
           └ MyLifecycleAwareThing (Created?)
       """.trimIndent() + '\n'
@@ -73,4 +76,5 @@ public class StatePrinterTest {
 private class DummyLifecycleOwner : LifecycleAwareComponent()
 private class MyJourney : LifecycleAwareComponent()
 private class MyStep : LifecycleAwareComponent()
+private class MySection : LifecycleAwareComponent()
 private class MyLifecycleAwareThing : LifecycleAware


### PR DESCRIPTION
Whoops, this is getting pretty big. Here's what's here:

- Refactor NavigationDelegate to be based on LifecycleLimiter
- Fix some issues with LifecycleLimiter
  - Properly transition states
  - Only pass backPressed() events to Shown or Resumed children
- Add assertions for transitioning lifecycles from unexpected states and attaching or detaching multiple times
- Fix a bug in the StatePrinter