### PR TITLE
Pass application context in create() and destroy() to prevent leaks

### DIFF
--- a/magellan-legacy/src/main/java/com/wealthfront/magellan/LegacyViewComponent.java
+++ b/magellan-legacy/src/main/java/com/wealthfront/magellan/LegacyViewComponent.java
@@ -20,11 +20,6 @@ public class LegacyViewComponent<V extends ViewGroup & ScreenView> implements Li
   }
 
   @Override
-  public void create(@NotNull Context context) {
-    setActivity(context);
-  }
-
-  @Override
   public void show(@NotNull Context context) {
     setActivity(context);
     V view = screen.createView(context);

--- a/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/ActivityLifecycleAdapter.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/ActivityLifecycleAdapter.kt
@@ -17,7 +17,7 @@ internal class ActivityLifecycleAdapter(
 
   override fun onCreate(owner: ActivityLifecycleOwner) {
     if (navigable is MagellanLifecycleOwner && navigable.currentState == LifecycleState.Destroyed) {
-      navigable.create(context)
+      navigable.create(context.applicationContext)
     }
   }
 
@@ -41,7 +41,7 @@ internal class ActivityLifecycleAdapter(
 
   override fun onDestroy(owner: ActivityLifecycleOwner) {
     if (context.isFinishing) {
-      navigable.destroy(context)
+      navigable.destroy(context.applicationContext)
     }
   }
 }


### PR DESCRIPTION
Some lifecycle components will hold on to the `Created` lifecycle state object, which can therefore live longer than an activity. We shouldn't pass an activity context for `Created` to prevent these leaks.