### PR TITLE
Better handle onDestroy events

### DIFF
--- a/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleExtensions.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleExtensions.kt
@@ -45,14 +45,21 @@ public fun <CustomLifecycleAware : LifecycleAware> LifecycleOwner.lateinitLifecy
 
 public class LateinitLifecycle<CustomLifecycleAware : LifecycleAware>(private val parent: LifecycleOwner) {
 
-  private lateinit var lifecycleAware: CustomLifecycleAware
+  private var lifecycleAware: CustomLifecycleAware? = null
 
   public operator fun getValue(thisRef: Any?, property: KProperty<*>): CustomLifecycleAware {
-    return lifecycleAware
+    return lifecycleAware ?: error(
+      "This lateinit LifecycleAware has not been set yet. (Has your dependency injection run yet?)"
+    )
   }
 
   public operator fun setValue(thisRef: Any?, property: KProperty<*>, value: CustomLifecycleAware) {
-    lifecycleAware = value
-    parent.attachToLifecycle(lifecycleAware)
+    if (value != lifecycleAware) {
+      if (lifecycleAware != null) {
+        parent.removeFromLifecycle(lifecycleAware!!)
+      }
+      lifecycleAware = value
+      parent.attachToLifecycle(lifecycleAware!!)
+    }
   }
 }

--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationDelegate.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationDelegate.kt
@@ -53,7 +53,7 @@ public class NavigationDelegate(
   }
 
   override fun onDestroy(context: Context) {
-    backStack.navigables().forEach { removeFromLifecycle(it) }
+    backStack.navigables().forEach { lifecycleLimiter.removeFromLifecycle(it) }
     backStack.clear()
     containerView = null
   }


### PR DESCRIPTION
- Properly detach items from the navigator in onDestroy
- Make `by lateinitLifecycle` idempotent (i.e. allow setting the property multiple times)