### PR TITLE
Avoid leaking activity context by passing application context to Created

### DIFF
--- a/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleRegistry.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleRegistry.kt
@@ -81,7 +81,7 @@ internal class LifecycleRegistry : LifecycleAware {
   }
 
   override fun create(context: Context) {
-    currentState = LifecycleState.Created(context)
+    currentState = LifecycleState.Created(context.applicationContext)
   }
 
   override fun show(context: Context) {
@@ -97,7 +97,7 @@ internal class LifecycleRegistry : LifecycleAware {
   }
 
   override fun hide(context: Context) {
-    currentState = LifecycleState.Created(context)
+    currentState = LifecycleState.Created(context.applicationContext)
   }
 
   override fun destroy(context: Context) {

--- a/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleStateMachine.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleStateMachine.kt
@@ -32,7 +32,7 @@ internal class LifecycleStateMachine {
     while (currentState.order != newState.order) {
       currentState = when (currentState.getDirectionForMovement(newState)) {
         FORWARD -> next(subjects, currentState, newState.context!!)
-        BACKWARDS -> previous(subjects, currentState, getContext(newState, oldState))
+        BACKWARDS -> previous(subjects, currentState, oldState.context!!)
         NO_MOVEMENT -> throw IllegalStateException("Attempting to transition from $currentState to $newState")
       }
     }
@@ -45,8 +45,8 @@ internal class LifecycleStateMachine {
   ): LifecycleState {
     return when (currentState) {
       is Destroyed -> {
-        subjects.forEach { it.create(context) }
-        Created(context)
+        subjects.forEach { it.create(context.applicationContext) }
+        Created(context.applicationContext)
       }
       is Created -> {
         subjects.forEach { it.show(context) }
@@ -72,21 +72,17 @@ internal class LifecycleStateMachine {
         throw IllegalStateException("Cannot go backward from destroyed")
       }
       is Created -> {
-        subjects.forEach { it.destroy(context) }
+        subjects.forEach { it.destroy(context.applicationContext) }
         Destroyed
       }
       is Shown -> {
         subjects.forEach { it.hide(context) }
-        Created(context)
+        Created(context.applicationContext)
       }
       is Resumed -> {
         subjects.forEach { it.pause(context) }
         Shown(context)
       }
     }
-  }
-
-  private fun getContext(newState: LifecycleState, oldState: LifecycleState): Context {
-    return newState.context ?: oldState.context!!
   }
 }

--- a/magellan-library/src/test/java/com/wealthfront/magellan/lifecycle/LifecycleStateMachineTest.kt
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/lifecycle/LifecycleStateMachineTest.kt
@@ -9,15 +9,18 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.InOrder
 import org.mockito.Mock
+import org.mockito.Mockito.`when`
 import org.mockito.Mockito.inOrder
 import org.mockito.Mockito.verifyNoMoreInteractions
+import org.mockito.Mockito.verifyZeroInteractions
 import org.mockito.MockitoAnnotations.initMocks
 
-class LifecycleStateMachineTest {
+internal class LifecycleStateMachineTest {
 
   private val lifecycleStateMachine = LifecycleStateMachine()
 
   @Mock lateinit var lifecycleAware: LifecycleAware
+  @Mock lateinit var applicationContext: Context
   @Mock lateinit var context: Context
 
   private lateinit var inOrder: InOrder
@@ -32,16 +35,19 @@ class LifecycleStateMachineTest {
 
     inOrder = inOrder(lifecycleAware)
     destroyed = Destroyed
-    created = Created(context)
+    created = Created(applicationContext)
     shown = Shown(context)
     resumed = Resumed(context)
+
+    `when`(context.applicationContext).thenReturn(applicationContext)
+    `when`(applicationContext.applicationContext).thenReturn(applicationContext)
   }
 
   @Test
   fun transitionBetweenLifecycleStates_createToCreated() {
     lifecycleStateMachine.transition(lifecycleAware, created, created)
 
-    verifyNoMoreInteractions(lifecycleAware)
+    verifyZeroInteractions(lifecycleAware)
   }
 
   @Test
@@ -65,7 +71,7 @@ class LifecycleStateMachineTest {
   fun transitionBetweenLifecycleStates_createToDestroy() {
     lifecycleStateMachine.transition(lifecycleAware, created, destroyed)
 
-    inOrder.verify(lifecycleAware).destroy(context)
+    inOrder.verify(lifecycleAware).destroy(applicationContext)
     verifyNoMoreInteractions(lifecycleAware)
   }
 
@@ -81,7 +87,7 @@ class LifecycleStateMachineTest {
   fun transitionBetweenLifecycleStates_shownToShown() {
     lifecycleStateMachine.transition(lifecycleAware, shown, shown)
 
-    verifyNoMoreInteractions(lifecycleAware)
+    verifyZeroInteractions(lifecycleAware)
   }
 
   @Test
@@ -97,7 +103,7 @@ class LifecycleStateMachineTest {
     lifecycleStateMachine.transition(lifecycleAware, shown, destroyed)
 
     inOrder.verify(lifecycleAware).hide(context)
-    inOrder.verify(lifecycleAware).destroy(context)
+    inOrder.verify(lifecycleAware).destroy(applicationContext)
     verifyNoMoreInteractions(lifecycleAware)
   }
 
@@ -122,7 +128,7 @@ class LifecycleStateMachineTest {
   fun transitionBetweenLifecycleStates_resumedToResumed() {
     lifecycleStateMachine.transition(lifecycleAware, resumed, resumed)
 
-    verifyNoMoreInteractions(lifecycleAware)
+    verifyZeroInteractions(lifecycleAware)
   }
 
   @Test
@@ -131,7 +137,7 @@ class LifecycleStateMachineTest {
 
     inOrder.verify(lifecycleAware).pause(context)
     inOrder.verify(lifecycleAware).hide(context)
-    inOrder.verify(lifecycleAware).destroy(context)
+    inOrder.verify(lifecycleAware).destroy(applicationContext)
     verifyNoMoreInteractions(lifecycleAware)
   }
 
@@ -139,7 +145,7 @@ class LifecycleStateMachineTest {
   fun transitionBetweenLifecycleStates_destroyedToCreated() {
     lifecycleStateMachine.transition(lifecycleAware, destroyed, created)
 
-    inOrder.verify(lifecycleAware).create(context)
+    inOrder.verify(lifecycleAware).create(applicationContext)
     verifyNoMoreInteractions(lifecycleAware)
   }
 
@@ -147,7 +153,7 @@ class LifecycleStateMachineTest {
   fun transitionBetweenLifecycleStates_destroyedToShown() {
     lifecycleStateMachine.transition(lifecycleAware, destroyed, shown)
 
-    inOrder.verify(lifecycleAware).create(context)
+    inOrder.verify(lifecycleAware).create(applicationContext)
     inOrder.verify(lifecycleAware).show(context)
     verifyNoMoreInteractions(lifecycleAware)
   }
@@ -156,7 +162,7 @@ class LifecycleStateMachineTest {
   fun transitionBetweenLifecycleStates_destroyedToResumed() {
     lifecycleStateMachine.transition(lifecycleAware, destroyed, resumed)
 
-    inOrder.verify(lifecycleAware).create(context)
+    inOrder.verify(lifecycleAware).create(applicationContext)
     inOrder.verify(lifecycleAware).show(context)
     inOrder.verify(lifecycleAware).resume(context)
     verifyNoMoreInteractions(lifecycleAware)
@@ -166,6 +172,6 @@ class LifecycleStateMachineTest {
   fun transitionBetweenLifecycleStates_destroyedToDestroy() {
     lifecycleStateMachine.transition(lifecycleAware, destroyed, destroyed)
 
-    verifyNoMoreInteractions(lifecycleAware)
+    verifyZeroInteractions(lifecycleAware)
   }
 }


### PR DESCRIPTION
We hang on to the `Created` event object potentially long past the associated activity is destroyed.

I don't like how opaque the API is now, however. We should consider passing in `Application` and `Activity` objects to make the different lifecycle events have explicitly different types of `Context`. But later.