### PR TITLE
Call onCreate immediately when attaching to activity lifecycle

### DIFF
--- a/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/ActivityLifecycleAdapter.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/ActivityLifecycleAdapter.kt
@@ -8,18 +8,11 @@ import com.wealthfront.magellan.R
 import com.wealthfront.magellan.ScreenContainer
 import com.wealthfront.magellan.core.Navigable
 import androidx.lifecycle.LifecycleOwner as ActivityLifecycleOwner
-import com.wealthfront.magellan.lifecycle.LifecycleOwner as MagellanLifecycleOwner
 
 internal class ActivityLifecycleAdapter(
   private val navigable: Navigable,
   private val context: Activity
 ) : DefaultLifecycleObserver {
-
-  override fun onCreate(owner: ActivityLifecycleOwner) {
-    if (navigable is MagellanLifecycleOwner && navigable.currentState == LifecycleState.Destroyed) {
-      navigable.create(context.applicationContext)
-    }
-  }
 
   override fun onStart(owner: ActivityLifecycleOwner) {
     navigable.show(context)
@@ -48,10 +41,16 @@ internal class ActivityLifecycleAdapter(
 
 public fun ComponentActivity.setContentScreen(navigable: Navigable, @LayoutRes root: Int = R.layout.magellan_root) {
   setContentView(root)
+  if (navigable is LifecycleOwner && navigable.currentState == LifecycleState.Destroyed) {
+    navigable.create(applicationContext)
+  }
   lifecycle.addObserver(ActivityLifecycleAdapter(navigable, this))
 }
 
 @Deprecated("This method exists for migration purposes.", ReplaceWith("setContentScreen(navigable)"))
 public fun ComponentActivity.setExpedition(navigable: Navigable) {
+  if (navigable is LifecycleOwner && navigable.currentState == LifecycleState.Destroyed) {
+    navigable.create(applicationContext)
+  }
   lifecycle.addObserver(ActivityLifecycleAdapter(navigable, this))
 }


### PR DESCRIPTION
This highlights the main difference between Magellan's and android's default lifecycle management; in Magellan world, children are set up before their parents so the parent can interact with them in the corresponding lifecycle event. Calling onCreate immediately here allows us to keep Magellan's mental model when interacting with our `Expedition` it in an activity.