### PR TITLE
Fix overlapping activities bug

### DIFF
--- a/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/ActivityLifecycleAdapter.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/ActivityLifecycleAdapter.kt
@@ -1,13 +1,19 @@
 package com.wealthfront.magellan.lifecycle
 
 import android.app.Activity
+import android.content.Context
 import androidx.activity.ComponentActivity
 import androidx.annotation.LayoutRes
 import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle as ActivityLifecycle
+import androidx.lifecycle.LifecycleOwner as ActivityLifecycleOwner
 import com.wealthfront.magellan.R
 import com.wealthfront.magellan.ScreenContainer
 import com.wealthfront.magellan.core.Navigable
-import androidx.lifecycle.LifecycleOwner as ActivityLifecycleOwner
+import com.wealthfront.magellan.lifecycle.LifecycleState.Created
+import com.wealthfront.magellan.lifecycle.LifecycleState.Destroyed
+
+private var adapterMap = emptyMap<Navigable, Pair<ActivityLifecycleAdapter, ActivityLifecycle>>()
 
 internal class ActivityLifecycleAdapter(
   private val navigable: Navigable,
@@ -33,24 +39,48 @@ internal class ActivityLifecycleAdapter(
   }
 
   override fun onDestroy(owner: ActivityLifecycleOwner) {
+    navigable.detachAndRemoveFromStaticMap(context.applicationContext)
     if (context.isFinishing) {
       navigable.destroy(context.applicationContext)
     }
   }
 }
 
-public fun ComponentActivity.setContentScreen(navigable: Navigable, @LayoutRes root: Int = R.layout.magellan_root) {
+public fun ComponentActivity.setContentScreen(
+  navigable: Navigable,
+  @LayoutRes root: Int = R.layout.magellan_root
+) {
   setContentView(root)
-  if (navigable is LifecycleOwner && navigable.currentState == LifecycleState.Destroyed) {
-    navigable.create(applicationContext)
-  }
-  lifecycle.addObserver(ActivityLifecycleAdapter(navigable, this))
+  @Suppress("DEPRECATION") setExpedition(navigable)
 }
 
-@Deprecated("This method exists for migration purposes.", ReplaceWith("setContentScreen(navigable)"))
+@Deprecated(
+  "This method exists for migration purposes.",
+  ReplaceWith("setContentScreen(navigable)"))
 public fun ComponentActivity.setExpedition(navigable: Navigable) {
-  if (navigable is LifecycleOwner && navigable.currentState == LifecycleState.Destroyed) {
+  if (navigable is LifecycleOwner && navigable.currentState == Destroyed) {
     navigable.create(applicationContext)
   }
-  lifecycle.addObserver(ActivityLifecycleAdapter(navigable, this))
+  if (adapterMap.containsKey(navigable)) {
+    navigable.detachAndRemoveFromStaticMap(applicationContext)
+  }
+  val lifecycleAdapter = ActivityLifecycleAdapter(navigable, this)
+  navigable.attachAndAddToStaticMap(lifecycleAdapter, lifecycle)
+}
+
+private fun Navigable.attachAndAddToStaticMap(
+  lifecycleAdapter: ActivityLifecycleAdapter,
+  lifecycle: ActivityLifecycle
+) {
+  lifecycle.addObserver(lifecycleAdapter)
+  adapterMap = adapterMap + (this to (lifecycleAdapter to lifecycle))
+}
+
+private fun Navigable.detachAndRemoveFromStaticMap(applicationContext: Context) {
+  val (lifecycleAdapter, lifecycle) = adapterMap[this]!!
+  lifecycle.removeObserver(lifecycleAdapter)
+  if (this is LifecycleOwner && currentState !is Created) {
+    LifecycleStateMachine().transition(this, currentState, Created(applicationContext))
+  }
+  adapterMap = adapterMap - this
 }


### PR DESCRIPTION
Should fix the bug we're seeing around one activity being started before the other one's torn down.

Unfortunately, gradle isn't working on my m1 mac so I can't run it right now. I added tests in another PR so we can merge this and get those working when I have my laptop again.