### PR TITLE
Null-out view reference in onStop

### DIFF
--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationDelegate.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationDelegate.kt
@@ -52,10 +52,13 @@ public class NavigationDelegate(
     }
   }
 
+  override fun onHide(context: Context) {
+    containerView = null
+  }
+
   override fun onDestroy(context: Context) {
     backStack.navigables().forEach { lifecycleLimiter.removeFromLifecycle(it) }
     backStack.clear()
-    containerView = null
   }
 
   public fun goTo(


### PR DESCRIPTION
this should fix memory leaks we see when the Activity gets torn down by the system