### PR TITLE
Rename onShow to onStart in M2.0

### DIFF
--- a/magellan-legacy/src/main/java/com/wealthfront/magellan/LegacyJourney.kt
+++ b/magellan-legacy/src/main/java/com/wealthfront/magellan/LegacyJourney.kt
@@ -6,7 +6,7 @@ import com.wealthfront.magellan.core.Step
 import com.wealthfront.magellan.lifecycle.attachFieldToLifecycle
 import com.wealthfront.magellan.navigation.CurrentNavigableProvider
 
-public abstract class LegacyExpedition<V : ViewBinding>(
+public abstract class LegacyJourney<V : ViewBinding>(
   createBinding: (LayoutInflater) -> V,
   container: V.() -> ScreenContainer
 ) : Step<V>(createBinding) {

--- a/magellan-legacy/src/main/java/com/wealthfront/magellan/LegacyViewComponent.java
+++ b/magellan-legacy/src/main/java/com/wealthfront/magellan/LegacyViewComponent.java
@@ -20,7 +20,7 @@ public class LegacyViewComponent<V extends ViewGroup & ScreenView> implements Li
   }
 
   @Override
-  public void show(@NotNull Context context) {
+  public void start(@NotNull Context context) {
     setActivity(context);
     V view = screen.createView(context);
     // noinspection unchecked
@@ -32,7 +32,7 @@ public class LegacyViewComponent<V extends ViewGroup & ScreenView> implements Li
   }
 
   @Override
-  public void hide(@NotNull Context context) {
+  public void stop(@NotNull Context context) {
     V view = screen.getView();
     if (view != null) {
       viewState = new SparseArray<>();

--- a/magellan-legacy/src/main/java/com/wealthfront/magellan/Screen.java
+++ b/magellan-legacy/src/main/java/com/wealthfront/magellan/Screen.java
@@ -143,8 +143,12 @@ public abstract class Screen<V extends ViewGroup & ScreenView> extends Lifecycle
   /**
    * Called when the Screen in shown (including on rotation).
    */
+  protected void onShow(@NotNull Context context) {
+    onStart(context);
+  }
+
   @Override
-  protected void onShow(@NotNull Context context) { }
+  final protected void onStart(@NotNull Context context) { }
 
   /**
    * Called when the activity is resumed and when the Screen is shown.
@@ -162,6 +166,10 @@ public abstract class Screen<V extends ViewGroup & ScreenView> extends Lifecycle
    * Called when the Screen is hidden (including on rotation).
    */
   @Override
+  final protected void onStop(@NotNull Context context) {
+    onHide(context);
+  }
+
   protected void onHide(@NotNull Context context) { }
 
   /**

--- a/magellan-legacy/src/main/java/com/wealthfront/magellan/Screen.java
+++ b/magellan-legacy/src/main/java/com/wealthfront/magellan/Screen.java
@@ -143,12 +143,12 @@ public abstract class Screen<V extends ViewGroup & ScreenView> extends Lifecycle
   /**
    * Called when the Screen in shown (including on rotation).
    */
-  protected void onShow(@NotNull Context context) {
-    onStart(context);
-  }
+  protected void onShow(@NotNull Context context) { }
 
   @Override
-  final protected void onStart(@NotNull Context context) { }
+  final protected void onStart(@NotNull Context context) {
+    onShow(context);
+  }
 
   /**
    * Called when the activity is resumed and when the Screen is shown.
@@ -165,12 +165,12 @@ public abstract class Screen<V extends ViewGroup & ScreenView> extends Lifecycle
   /**
    * Called when the Screen is hidden (including on rotation).
    */
+  protected void onHide(@NotNull Context context) { }
+
   @Override
   final protected void onStop(@NotNull Context context) {
     onHide(context);
   }
-
-  protected void onHide(@NotNull Context context) { }
 
   /**
    * Called when the Screen is navigated away from after the screen is hidden (not triggered on rotation).

--- a/magellan-legacy/src/test/java/com/wealthfront/magellan/HistoryRewriterExtensionsKtTest.kt
+++ b/magellan-legacy/src/test/java/com/wealthfront/magellan/HistoryRewriterExtensionsKtTest.kt
@@ -15,7 +15,7 @@ import java.util.ArrayDeque
 
 public class HistoryRewriterExtensionsKtTest {
 
-  private lateinit var root: LegacyExpedition<*>
+  private lateinit var root: LegacyJourney<*>
   private lateinit var journey1: Journey<*>
   private lateinit var screen: Screen<*>
   @Mock private lateinit var view: BaseScreenView<DummyScreen>
@@ -95,7 +95,7 @@ public class HistoryRewriterExtensionsKtTest {
     historyRewriter.rewriteHistoryWithNavigationEvents(backStack)
   }
 
-  private inner class RootJourney : LegacyExpedition<MagellanDummyLayoutBinding>(
+  private inner class RootJourney : LegacyJourney<MagellanDummyLayoutBinding>(
     MagellanDummyLayoutBinding::inflate,
     MagellanDummyLayoutBinding::container
   )

--- a/magellan-legacy/src/test/java/com/wealthfront/magellan/LegacyViewComponentTest.java
+++ b/magellan-legacy/src/test/java/com/wealthfront/magellan/LegacyViewComponentTest.java
@@ -38,7 +38,7 @@ public class LegacyViewComponentTest {
 
     assertThat(screen.getView()).isEqualTo(null);
 
-    legacyViewComponent.show(context);
+    legacyViewComponent.start(context);
 
     assertThat(screen.getView()).isEqualTo(view);
     assertThat(screen.getActivity()).isEqualTo(context);
@@ -54,7 +54,7 @@ public class LegacyViewComponentTest {
     assertThat(screen.getView()).isEqualTo(view);
     assertThat(screen.getActivity()).isEqualTo(context);
 
-    legacyViewComponent.hide(context);
+    legacyViewComponent.stop(context);
 
     assertThat(screen.getView()).isEqualTo(null);
     verify(view).saveHierarchyState(isA(SparseArray.class));
@@ -65,19 +65,19 @@ public class LegacyViewComponentTest {
   @Test
   public void viewComponentLifecycleConfigChange() {
     legacyViewComponent.create(context);
-    legacyViewComponent.show(context);
+    legacyViewComponent.start(context);
     legacyViewComponent.resume(context);
 
     assertThat(screen.getView()).isEqualTo(view);
     assertThat(screen.getActivity()).isEqualTo(context);
 
     legacyViewComponent.pause(context);
-    legacyViewComponent.hide(context);
+    legacyViewComponent.stop(context);
 
     assertThat(screen.getView()).isEqualTo(null);
     assertThat(screen.getActivity()).isEqualTo(null);
 
-    legacyViewComponent.show(context);
+    legacyViewComponent.start(context);
     legacyViewComponent.resume(context);
 
     assertThat(screen.getView()).isEqualTo(view);
@@ -89,7 +89,7 @@ public class LegacyViewComponentTest {
     viewComponentLifecycleUntilDestroy();
 
     legacyViewComponent.create(context);
-    legacyViewComponent.show(context);
+    legacyViewComponent.start(context);
     legacyViewComponent.resume(context);
 
     assertThat(screen.getView()).isEqualTo(view);

--- a/magellan-legacy/src/test/java/com/wealthfront/magellan/ScreenGroupTest.java
+++ b/magellan-legacy/src/test/java/com/wealthfront/magellan/ScreenGroupTest.java
@@ -46,7 +46,7 @@ public class ScreenGroupTest {
   @Test
   public void addScreen() {
     screenGroup.create(context);
-    screenGroup.show(context);
+    screenGroup.start(context);
     screenGroup.resume(context);
 
     screenGroup.addScreen(screen3);

--- a/magellan-legacy/src/test/java/com/wealthfront/magellan/ScreenTest.java
+++ b/magellan-legacy/src/test/java/com/wealthfront/magellan/ScreenTest.java
@@ -38,7 +38,7 @@ public class ScreenTest {
     assertThat(screen.getView()).isEqualTo(null);
 
     screen.create(context);
-    screen.show(context);
+    screen.start(context);
     screen.resume(context);
 
     assertThat(screen.getActivity()).isEqualTo(context);
@@ -51,10 +51,10 @@ public class ScreenTest {
     assertThat(screen.getView()).isEqualTo(null);
 
     screen.create(context);
-    screen.show(context);
+    screen.start(context);
     screen.resume(context);
     screen.pause(context);
-    screen.hide(context);
+    screen.stop(context);
 
     assertThat(screen.getActivity()).isEqualTo(null);
     assertThat(screen.getView()).isEqualTo(null);
@@ -66,10 +66,10 @@ public class ScreenTest {
     assertThat(screen.getView()).isEqualTo(null);
 
     screen.create(context);
-    screen.show(context);
+    screen.start(context);
     screen.resume(context);
     screen.pause(context);
-    screen.hide(context);
+    screen.stop(context);
     screen.destroy(context);
 
     assertThat(screen.getActivity()).isEqualTo(null);
@@ -83,19 +83,19 @@ public class ScreenTest {
     assertThat(screen.getView()).isEqualTo(null);
 
     screen.create(context);
-    screen.show(context);
+    screen.start(context);
     screen.resume(context);
 
     assertThat(screen.getActivity()).isEqualTo(context);
     assertThat(screen.getView()).isEqualTo(view);
 
     screen.pause(context);
-    screen.hide(context);
+    screen.stop(context);
 
     assertThat(screen.getActivity()).isEqualTo(null);
     assertThat(screen.getView()).isEqualTo(null);
 
-    screen.show(context);
+    screen.start(context);
     screen.resume(context);
 
     assertThat(screen.getActivity()).isEqualTo(context);

--- a/magellan-library/src/main/java/com/wealthfront/magellan/core/Step.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/core/Step.kt
@@ -28,9 +28,9 @@ public abstract class Step<V : ViewBinding>(
   public var shownScope: CoroutineScope by attachFieldToLifecycle(ShownLifecycleScope()) { it }
     @VisibleForTesting set
 
-  final override fun onShow(context: Context) {
+  final override fun onStart(context: Context) {
     restoreViewState()
-    onShow(context, viewBinding!!)
+    onStart(context, viewBinding!!)
   }
 
   final override fun onResume(context: Context) {
@@ -41,8 +41,8 @@ public abstract class Step<V : ViewBinding>(
     onPause(context, viewBinding!!)
   }
 
-  final override fun onHide(context: Context) {
-    onHide(context, viewBinding!!)
+  final override fun onStop(context: Context) {
+    onStop(context, viewBinding!!)
     saveViewState()
   }
 
@@ -58,11 +58,11 @@ public abstract class Step<V : ViewBinding>(
     view!!.saveHierarchyState(viewState)
   }
 
-  protected open fun onShow(context: Context, binding: V) {}
+  protected open fun onStart(context: Context, binding: V) {}
 
   protected open fun onResume(context: Context, binding: V) {}
 
   protected open fun onPause(context: Context, binding: V) {}
 
-  protected open fun onHide(context: Context, binding: V) {}
+  protected open fun onStop(context: Context, binding: V) {}
 }

--- a/magellan-library/src/main/java/com/wealthfront/magellan/coroutines/ShownLifecycleScope.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/coroutines/ShownLifecycleScope.kt
@@ -20,11 +20,11 @@ public class ShownLifecycleScope @Inject constructor() : LifecycleAware, Corouti
   override var coroutineContext: CoroutineContext = job + Dispatchers.Main
     private set
 
-  override fun show(context: Context) {
+  override fun start(context: Context) {
     job = SupervisorJob()
   }
 
-  override fun hide(context: Context) {
+  override fun stop(context: Context) {
     job.cancel(CancellationException("Hidden"))
   }
 }

--- a/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/ActivityLifecycleAdapter.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/ActivityLifecycleAdapter.kt
@@ -21,7 +21,7 @@ internal class ActivityLifecycleAdapter(
 ) : DefaultLifecycleObserver {
 
   override fun onStart(owner: ActivityLifecycleOwner) {
-    navigable.show(context)
+    navigable.start(context)
     context.findViewById<ScreenContainer>(R.id.magellan_container).addView(navigable.view!!)
   }
 
@@ -34,7 +34,7 @@ internal class ActivityLifecycleAdapter(
   }
 
   override fun onStop(owner: ActivityLifecycleOwner) {
-    navigable.hide(context)
+    navigable.stop(context)
     context.findViewById<ScreenContainer>(R.id.magellan_container).removeAllViews()
   }
 

--- a/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleAware.java
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleAware.java
@@ -8,13 +8,13 @@ public interface LifecycleAware {
   
   default void create(@NotNull Context context) {}
 
-  default void show(@NotNull Context context) {}
+  default void start(@NotNull Context context) {}
 
   default void resume(@NotNull Context context) {}
 
   default void pause(@NotNull Context context) {}
 
-  default void hide(@NotNull Context context) {}
+  default void stop(@NotNull Context context) {}
 
   default void destroy(@NotNull Context context) {}
 

--- a/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleAwareComponent.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleAwareComponent.kt
@@ -23,15 +23,15 @@ public abstract class LifecycleAwareComponent : LifecycleAware, LifecycleOwner {
     onCreate(context)
   }
 
-  final override fun show(context: Context) {
+  final override fun start(context: Context) {
     if (currentState !is LifecycleState.Created) {
       throw IllegalStateException(
         "Cannot show() from a state that is not Created: " +
           "${this::class.java.simpleName} is ${currentState::class.java.simpleName}"
       )
     }
-    lifecycleRegistry.show(context)
-    onShow(context)
+    lifecycleRegistry.start(context)
+    onStart(context)
   }
 
   final override fun resume(context: Context) {
@@ -56,15 +56,15 @@ public abstract class LifecycleAwareComponent : LifecycleAware, LifecycleOwner {
     lifecycleRegistry.pause(context)
   }
 
-  final override fun hide(context: Context) {
+  final override fun stop(context: Context) {
     if (currentState !is LifecycleState.Shown) {
       throw IllegalStateException(
         "Cannot hide() from a state that is not Shown: " +
           "${this::class.java.simpleName} is ${currentState::class.java.simpleName}"
       )
     }
-    onHide(context)
-    lifecycleRegistry.hide(context)
+    onStop(context)
+    lifecycleRegistry.stop(context)
   }
 
   final override fun destroy(context: Context) {
@@ -100,13 +100,13 @@ public abstract class LifecycleAwareComponent : LifecycleAware, LifecycleOwner {
 
   protected open fun onCreate(context: Context) {}
 
-  protected open fun onShow(context: Context) {}
+  protected open fun onStart(context: Context) {}
 
   protected open fun onResume(context: Context) {}
 
   protected open fun onPause(context: Context) {}
 
-  protected open fun onHide(context: Context) {}
+  protected open fun onStop(context: Context) {}
 
   protected open fun onDestroy(context: Context) {}
 

--- a/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleLimiter.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleLimiter.kt
@@ -18,8 +18,8 @@ public class LifecycleLimiter : LifecycleOwner, LifecycleAware {
     lifecycleRegistry.create(context)
   }
 
-  override fun show(context: Context) {
-    lifecycleRegistry.show(context)
+  override fun start(context: Context) {
+    lifecycleRegistry.start(context)
   }
 
   override fun resume(context: Context) {
@@ -30,8 +30,8 @@ public class LifecycleLimiter : LifecycleOwner, LifecycleAware {
     lifecycleRegistry.pause(context)
   }
 
-  override fun hide(context: Context) {
-    lifecycleRegistry.hide(context)
+  override fun stop(context: Context) {
+    lifecycleRegistry.stop(context)
   }
 
   override fun destroy(context: Context) {

--- a/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleRegistry.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleRegistry.kt
@@ -84,7 +84,7 @@ internal class LifecycleRegistry : LifecycleAware {
     currentState = LifecycleState.Created(context.applicationContext)
   }
 
-  override fun show(context: Context) {
+  override fun start(context: Context) {
     currentState = LifecycleState.Shown(context)
   }
 
@@ -96,7 +96,7 @@ internal class LifecycleRegistry : LifecycleAware {
     currentState = LifecycleState.Shown(context)
   }
 
-  override fun hide(context: Context) {
+  override fun stop(context: Context) {
     currentState = LifecycleState.Created(context.applicationContext)
   }
 

--- a/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleStateMachine.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/LifecycleStateMachine.kt
@@ -49,7 +49,7 @@ internal class LifecycleStateMachine {
         Created(context.applicationContext)
       }
       is Created -> {
-        subjects.forEach { it.show(context) }
+        subjects.forEach { it.start(context) }
         Shown(context)
       }
       is Shown -> {
@@ -76,7 +76,7 @@ internal class LifecycleStateMachine {
         Destroyed
       }
       is Shown -> {
-        subjects.forEach { it.hide(context) }
+        subjects.forEach { it.stop(context) }
         Created(context.applicationContext)
       }
       is Resumed -> {

--- a/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/ShownFieldFromContext.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/lifecycle/ShownFieldFromContext.kt
@@ -9,11 +9,11 @@ public class ShownFieldFromContext<Field>(
   public var field: Field? = null
     protected set
 
-  override fun show(context: Context) {
+  override fun start(context: Context) {
     field = fieldSupplier(context)
   }
 
-  override fun hide(context: Context) {
+  override fun stop(context: Context) {
     field = null
   }
 }

--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationDelegate.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationDelegate.kt
@@ -45,14 +45,14 @@ public class NavigationDelegate(
   private val context: Context?
     get() = currentState.context
 
-  override fun onShow(context: Context) {
+  override fun onStart(context: Context) {
     containerView = container()
     currentNavigable?.let {
       containerView!!.addView(currentNavigable!!.view!!)
     }
   }
 
-  override fun onHide(context: Context) {
+  override fun onStop(context: Context) {
     containerView = null
   }
 

--- a/magellan-library/src/test/java/com/wealthfront/magellan/core/StepTest.kt
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/core/StepTest.kt
@@ -45,7 +45,7 @@ internal class StepTest {
   @Test
   fun onShow() {
     screen.create(context)
-    screen.show(context)
+    screen.start(context)
 
     verify(view, never()).restoreHierarchyState(any())
   }
@@ -53,8 +53,8 @@ internal class StepTest {
   @Test
   fun onHide() {
     screen.create(context)
-    screen.show(context)
-    screen.hide(context)
+    screen.start(context)
+    screen.stop(context)
 
     verify(view).saveHierarchyState(any())
   }
@@ -66,13 +66,13 @@ internal class StepTest {
     doAnswer { sparseArrayCaptor.value.put(42, state) }.`when`(view).saveHierarchyState(sparseArrayCaptor.capture())
 
     screen.create(context)
-    screen.show(context)
-    screen.hide(context)
+    screen.start(context)
+    screen.stop(context)
     verify(view).saveHierarchyState(any())
 
     screen.destroy(context)
     screen.create(context)
-    screen.show(context)
+    screen.start(context)
     verify(view).restoreHierarchyState(sparseArrayCaptor.capture())
 
     val bundle = sparseArrayCaptor.value.get(42) as Bundle

--- a/magellan-library/src/test/java/com/wealthfront/magellan/coroutines/CreatedLifecycleScopeTest.kt
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/coroutines/CreatedLifecycleScopeTest.kt
@@ -40,13 +40,13 @@ internal class CreatedLifecycleScopeTest {
       assertThat(async.getCancellationException()).hasMessageThat().contains("Not created yet")
 
       createdScope.create(context)
-      createdScope.show(context)
+      createdScope.start(context)
       createdScope.resume(context)
 
       assertThat(async.isCancelled).isTrue()
 
       createdScope.pause(context)
-      createdScope.hide(context)
+      createdScope.stop(context)
 
       assertThat(async.isCancelled).isTrue()
       assertThat(async.getCancellationException()).hasMessageThat().contains("Not created yet")
@@ -61,13 +61,13 @@ internal class CreatedLifecycleScopeTest {
       val async = createdScope.async { delay(5000) }
       assertThat(async.isCancelled).isFalse()
 
-      createdScope.show(context)
+      createdScope.start(context)
       createdScope.resume(context)
 
       assertThat(async.isCancelled).isFalse()
 
       createdScope.pause(context)
-      createdScope.hide(context)
+      createdScope.stop(context)
 
       assertThat(async.isCancelled).isFalse()
 
@@ -82,7 +82,7 @@ internal class CreatedLifecycleScopeTest {
   fun cancelAfterShown() {
     runBlockingTest {
       createdScope.create(context)
-      createdScope.show(context)
+      createdScope.start(context)
 
       val async = createdScope.async { delay(5000) }
       assertThat(async.isCancelled).isFalse()
@@ -92,7 +92,7 @@ internal class CreatedLifecycleScopeTest {
       assertThat(async.isCancelled).isFalse()
 
       createdScope.pause(context)
-      createdScope.hide(context)
+      createdScope.stop(context)
 
       assertThat(async.isCancelled).isFalse()
 
@@ -107,14 +107,14 @@ internal class CreatedLifecycleScopeTest {
   fun cancelAfterResumed() {
     runBlockingTest {
       createdScope.create(context)
-      createdScope.show(context)
+      createdScope.start(context)
       createdScope.resume(context)
 
       val async = createdScope.async { delay(5000) }
       assertThat(async.isCancelled).isFalse()
 
       createdScope.pause(context)
-      createdScope.hide(context)
+      createdScope.stop(context)
 
       assertThat(async.isCancelled).isFalse()
 

--- a/magellan-library/src/test/java/com/wealthfront/magellan/coroutines/ShownLifecycleScopeTest.kt
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/coroutines/ShownLifecycleScopeTest.kt
@@ -40,13 +40,13 @@ internal class ShownLifecycleScopeTest {
       assertThat(async.isCancelled).isTrue()
       assertThat(async.getCancellationException()).hasMessageThat().contains("Not shown yet")
 
-      shownScope.show(context)
+      shownScope.start(context)
       shownScope.resume(context)
 
       assertThat(async.isCancelled).isTrue()
 
       shownScope.pause(context)
-      shownScope.hide(context)
+      shownScope.stop(context)
 
       assertThat(async.isCancelled).isTrue()
       assertThat(async.getCancellationException()).hasMessageThat().contains("Not shown yet")
@@ -57,7 +57,7 @@ internal class ShownLifecycleScopeTest {
   fun cancelAfterShown() {
     runBlockingTest {
       shownScope.create(context)
-      shownScope.show(context)
+      shownScope.start(context)
 
       val async = shownScope.async { delay(5000) }
       assertThat(async.isCancelled).isFalse()
@@ -67,7 +67,7 @@ internal class ShownLifecycleScopeTest {
       assertThat(async.isCancelled).isFalse()
 
       shownScope.pause(context)
-      shownScope.hide(context)
+      shownScope.stop(context)
 
       assertThat(async.isCancelled).isTrue()
       assertThat(async.getCancellationException()).hasMessageThat().contains("Hidden")
@@ -78,7 +78,7 @@ internal class ShownLifecycleScopeTest {
   fun cancelMultipleAfterShown() {
     runBlockingTest {
       shownScope.create(context)
-      shownScope.show(context)
+      shownScope.start(context)
 
       val async = shownScope.async { delay(5000) }
       val async2 = shownScope.async { delay(5000) }
@@ -91,7 +91,7 @@ internal class ShownLifecycleScopeTest {
       assertThat(async2.isCancelled).isFalse()
 
       shownScope.pause(context)
-      shownScope.hide(context)
+      shownScope.stop(context)
 
       assertThat(async.isCancelled).isTrue()
       assertThat(async.getCancellationException()).hasMessageThat().contains("Hidden")
@@ -104,14 +104,14 @@ internal class ShownLifecycleScopeTest {
   fun cancelAfterResumed() {
     runBlockingTest {
       shownScope.create(context)
-      shownScope.show(context)
+      shownScope.start(context)
       shownScope.resume(context)
 
       val async = shownScope.async { delay(5000) }
       assertThat(async.isCancelled).isFalse()
 
       shownScope.pause(context)
-      shownScope.hide(context)
+      shownScope.stop(context)
 
       assertThat(async.isCancelled).isTrue()
       assertThat(async.getCancellationException()).hasMessageThat().contains("Hidden")

--- a/magellan-library/src/test/java/com/wealthfront/magellan/debug/StatePrinterTest.kt
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/debug/StatePrinterTest.kt
@@ -41,7 +41,7 @@ public class StatePrinterTest {
     root.attachToLifecycle(MyStep())
     root.attachToLifecycle(MyStep())
     root.create(context)
-    root.show(context)
+    root.start(context)
     assertThat(root.getLifecycleStateSnapshot()).isEqualTo(
       """
         DummyLifecycleOwner (Shown)

--- a/magellan-library/src/test/java/com/wealthfront/magellan/lifecycle/LifecycleLimiterTest.kt
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/lifecycle/LifecycleLimiterTest.kt
@@ -25,7 +25,7 @@ internal class LifecycleLimiterTest {
   @Test
   fun attachToLifecycleWithMaxState() {
     lifecycleLimiter.create(context)
-    lifecycleLimiter.show(context)
+    lifecycleLimiter.start(context)
     lifecycleLimiter.resume(context)
 
     lifecycleLimiter.attachToLifecycle(dummyLifecycleComponent)
@@ -58,7 +58,7 @@ internal class LifecycleLimiterTest {
 
     assertThat(dummyLifecycleComponent.currentState).isEqualTo(LifecycleState.Created(context))
 
-    lifecycleLimiter.show(context)
+    lifecycleLimiter.start(context)
     lifecycleLimiter.resume(context)
 
     assertThat(dummyLifecycleComponent.currentState).isEqualTo(LifecycleState.Shown(context))
@@ -67,7 +67,7 @@ internal class LifecycleLimiterTest {
   @Test
   fun updateMaxStateForChild_afterEvents() {
     lifecycleLimiter.create(context)
-    lifecycleLimiter.show(context)
+    lifecycleLimiter.start(context)
     lifecycleLimiter.resume(context)
 
     lifecycleLimiter.attachToLifecycleWithMaxState(dummyLifecycleComponent, LifecycleLimit.CREATED)
@@ -86,7 +86,7 @@ internal class LifecycleLimiterTest {
   @Test
   fun onBackPressed_limited() {
     lifecycleLimiter.create(context)
-    lifecycleLimiter.show(context)
+    lifecycleLimiter.start(context)
     lifecycleLimiter.resume(context)
 
     var unwantedBackPressed = false
@@ -117,7 +117,7 @@ internal class LifecycleLimiterTest {
   @Test
   fun onBackPressed_notLimited() {
     lifecycleLimiter.create(context)
-    lifecycleLimiter.show(context)
+    lifecycleLimiter.start(context)
     lifecycleLimiter.resume(context)
 
     var wantedBackPressed = false

--- a/magellan-library/src/test/java/com/wealthfront/magellan/lifecycle/LifecycleStateMachineTest.kt
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/lifecycle/LifecycleStateMachineTest.kt
@@ -54,7 +54,7 @@ internal class LifecycleStateMachineTest {
   fun transitionBetweenLifecycleStates_createToShown() {
     lifecycleStateMachine.transition(lifecycleAware, created, shown)
 
-    inOrder.verify(lifecycleAware).show(context)
+    inOrder.verify(lifecycleAware).start(context)
     verifyNoMoreInteractions(lifecycleAware)
   }
 
@@ -62,7 +62,7 @@ internal class LifecycleStateMachineTest {
   fun transitionBetweenLifecycleStates_createToResumed() {
     lifecycleStateMachine.transition(lifecycleAware, created, resumed)
 
-    inOrder.verify(lifecycleAware).show(context)
+    inOrder.verify(lifecycleAware).start(context)
     inOrder.verify(lifecycleAware).resume(context)
     verifyNoMoreInteractions(lifecycleAware)
   }
@@ -79,7 +79,7 @@ internal class LifecycleStateMachineTest {
   fun transitionBetweenLifecycleStates_shownToCreated() {
     lifecycleStateMachine.transition(lifecycleAware, shown, created)
 
-    inOrder.verify(lifecycleAware).hide(context)
+    inOrder.verify(lifecycleAware).stop(context)
     verifyNoMoreInteractions(lifecycleAware)
   }
 
@@ -102,7 +102,7 @@ internal class LifecycleStateMachineTest {
   fun transitionBetweenLifecycleStates_shownToDestroy() {
     lifecycleStateMachine.transition(lifecycleAware, shown, destroyed)
 
-    inOrder.verify(lifecycleAware).hide(context)
+    inOrder.verify(lifecycleAware).stop(context)
     inOrder.verify(lifecycleAware).destroy(applicationContext)
     verifyNoMoreInteractions(lifecycleAware)
   }
@@ -112,7 +112,7 @@ internal class LifecycleStateMachineTest {
     lifecycleStateMachine.transition(lifecycleAware, resumed, created)
 
     inOrder.verify(lifecycleAware).pause(context)
-    inOrder.verify(lifecycleAware).hide(context)
+    inOrder.verify(lifecycleAware).stop(context)
     verifyNoMoreInteractions(lifecycleAware)
   }
 
@@ -136,7 +136,7 @@ internal class LifecycleStateMachineTest {
     lifecycleStateMachine.transition(lifecycleAware, resumed, destroyed)
 
     inOrder.verify(lifecycleAware).pause(context)
-    inOrder.verify(lifecycleAware).hide(context)
+    inOrder.verify(lifecycleAware).stop(context)
     inOrder.verify(lifecycleAware).destroy(applicationContext)
     verifyNoMoreInteractions(lifecycleAware)
   }
@@ -154,7 +154,7 @@ internal class LifecycleStateMachineTest {
     lifecycleStateMachine.transition(lifecycleAware, destroyed, shown)
 
     inOrder.verify(lifecycleAware).create(applicationContext)
-    inOrder.verify(lifecycleAware).show(context)
+    inOrder.verify(lifecycleAware).start(context)
     verifyNoMoreInteractions(lifecycleAware)
   }
 
@@ -163,7 +163,7 @@ internal class LifecycleStateMachineTest {
     lifecycleStateMachine.transition(lifecycleAware, destroyed, resumed)
 
     inOrder.verify(lifecycleAware).create(applicationContext)
-    inOrder.verify(lifecycleAware).show(context)
+    inOrder.verify(lifecycleAware).start(context)
     inOrder.verify(lifecycleAware).resume(context)
     verifyNoMoreInteractions(lifecycleAware)
   }

--- a/magellan-library/src/test/java/com/wealthfront/magellan/navigation/LinearNavigatorTest.kt
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/navigation/LinearNavigatorTest.kt
@@ -122,7 +122,7 @@ internal class LinearNavigatorTest {
   @Test
   fun goBack_journey_back() {
     activityController.restart()
-    linearNavigator.show(context)
+    linearNavigator.start(context)
     linearNavigator.resume(context)
     linearNavigator.navigate(FORWARD) {
       it.push(NavigationEvent(step1, DefaultTransition()))
@@ -142,7 +142,7 @@ internal class LinearNavigatorTest {
   @Test
   fun destroy() {
     activityController.restart()
-    linearNavigator.show(context)
+    linearNavigator.start(context)
     linearNavigator.resume(context)
     linearNavigator.navigate(FORWARD) {
       it.push(NavigationEvent(step1, DefaultTransition()))
@@ -154,7 +154,7 @@ internal class LinearNavigatorTest {
     assertThat(linearNavigator.backStack.size).isEqualTo(3)
 
     linearNavigator.pause(context)
-    linearNavigator.hide(context)
+    linearNavigator.stop(context)
     linearNavigator.destroy(context)
 
     assertThat(linearNavigator.backStack.size).isEqualTo(0)

--- a/magellan-library/src/test/java/com/wealthfront/magellan/view/DialogComponentTest.kt
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/view/DialogComponentTest.kt
@@ -37,7 +37,7 @@ internal class DialogComponentTest {
   fun showDialog() {
     `when`(dialog1.isShowing).thenReturn(true)
 
-    dialogComponent.show(context)
+    dialogComponent.start(context)
     dialogComponent.resume(context)
     dialogComponent.showDialog(dialogCreator1)
 
@@ -49,7 +49,7 @@ internal class DialogComponentTest {
   fun showDialog_hidden() {
     `when`(dialog1.isShowing).thenReturn(true)
 
-    dialogComponent.show(context)
+    dialogComponent.start(context)
     dialogComponent.resume(context)
     dialogComponent.showDialog(dialogCreator1)
 
@@ -58,7 +58,7 @@ internal class DialogComponentTest {
 
     `when`(dialog1.isShowing).thenReturn(false)
     dialogComponent.pause(context)
-    dialogComponent.hide(context)
+    dialogComponent.stop(context)
 
     verify(dialog1).dismiss()
     assertThat(dialogComponent.dialogIsShowing).isFalse()
@@ -67,7 +67,7 @@ internal class DialogComponentTest {
   @Test
   fun showDialog_rotation() {
     `when`(dialog1.isShowing).thenReturn(true)
-    dialogComponent.show(context)
+    dialogComponent.start(context)
     dialogComponent.resume(context)
     dialogComponent.showDialog(dialogCreator1)
 
@@ -75,12 +75,12 @@ internal class DialogComponentTest {
     assertThat(dialogComponent.dialogIsShowing).isTrue()
 
     dialogComponent.pause(context)
-    dialogComponent.hide(context)
+    dialogComponent.stop(context)
     dialogComponent.destroy(context)
 
     `when`(dialog1.isShowing).thenReturn(false)
     dialogComponent.create(context)
-    dialogComponent.show(context)
+    dialogComponent.start(context)
     dialogComponent.resume(context)
 
     verify(dialog1).dismiss()
@@ -93,7 +93,7 @@ internal class DialogComponentTest {
     `when`(dialog1.isShowing).thenReturn(true)
     `when`(dialog2.isShowing).thenReturn(true)
 
-    dialogComponent.show(context)
+    dialogComponent.start(context)
     dialogComponent.resume(context)
     dialogComponent.showDialog(dialogCreator1)
 

--- a/magellan-library/src/test/java/com/wealthfront/magellan/view/LifecycleViewTest.kt
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/view/LifecycleViewTest.kt
@@ -27,7 +27,7 @@ class LifecycleViewTest {
     lifecycleView.create(context)
     assertThat(lifecycleView.data).isEqualTo(null)
 
-    lifecycleView.show(context)
+    lifecycleView.start(context)
     assertThat(lifecycleView.data).isEqualTo(frameLayout)
 
     lifecycleView.resume(context)
@@ -36,7 +36,7 @@ class LifecycleViewTest {
     lifecycleView.pause(context)
     assertThat(lifecycleView.data).isEqualTo(frameLayout)
 
-    lifecycleView.hide(context)
+    lifecycleView.stop(context)
     assertThat(lifecycleView.data).isEqualTo(null)
 
     lifecycleView.destroy(context)
@@ -45,13 +45,13 @@ class LifecycleViewTest {
 
   @Test
   fun onCreateView() {
-    lifecycleView.show(context)
+    lifecycleView.start(context)
     assertThat(lifecycleView.data).isEqualTo(frameLayout)
   }
 
   @Test
   fun onDestroyView() {
-    lifecycleView.hide(context)
+    lifecycleView.stop(context)
     assertThat(lifecycleView.data).isEqualTo(null)
   }
 }

--- a/magellan-rx/src/main/java/com/wealthfront/magellan/rx/RxUnsubscriber.kt
+++ b/magellan-rx/src/main/java/com/wealthfront/magellan/rx/RxUnsubscriber.kt
@@ -21,7 +21,7 @@ public class RxUnsubscriber @Inject constructor() : LifecycleAware {
     subscription.forEach { autoUnsubscribe(it) }
   }
 
-  override fun hide(context: Context) {
+  override fun stop(context: Context) {
     subscriptions?.unsubscribe()
     subscriptions = null
   }

--- a/magellan-rx2/src/main/java/com/wealthfront/magellan/rx2/RxDisposer.kt
+++ b/magellan-rx2/src/main/java/com/wealthfront/magellan/rx2/RxDisposer.kt
@@ -21,7 +21,7 @@ public class RxDisposer @Inject constructor() : LifecycleAware {
     disposable.forEach { autoDispose(it) }
   }
 
-  override fun hide(context: Context) {
+  override fun stop(context: Context) {
     disposables?.dispose()
     disposables = null
   }

--- a/magellan-rx2/src/test/java/com/wealthfront/magellan/rx2/RxDisposerTest.kt
+++ b/magellan-rx2/src/test/java/com/wealthfront/magellan/rx2/RxDisposerTest.kt
@@ -30,10 +30,10 @@ class RxDisposerTest {
 
     assertThat(testSubscriber.isDisposed).isFalse()
 
-    rxDisposer.show(context)
+    rxDisposer.start(context)
     rxDisposer.resume(context)
     rxDisposer.pause(context)
-    rxDisposer.hide(context)
+    rxDisposer.stop(context)
 
     assertThat(testSubscriber.isDisposed).isTrue()
   }
@@ -43,7 +43,7 @@ class RxDisposerTest {
     assertThat(testSubscriber.isDisposed).isFalse()
 
     rxDisposer.create(context)
-    rxDisposer.show(context)
+    rxDisposer.start(context)
 
     rxDisposer.autoDispose(testSubscriber)
 
@@ -51,7 +51,7 @@ class RxDisposerTest {
 
     rxDisposer.resume(context)
     rxDisposer.pause(context)
-    rxDisposer.hide(context)
+    rxDisposer.stop(context)
 
     assertThat(testSubscriber.isDisposed).isTrue()
   }
@@ -61,7 +61,7 @@ class RxDisposerTest {
     assertThat(testSubscriber.isDisposed).isFalse()
 
     rxDisposer.create(context)
-    rxDisposer.show(context)
+    rxDisposer.start(context)
     rxDisposer.resume(context)
 
     rxDisposer.autoDispose(testSubscriber)
@@ -69,7 +69,7 @@ class RxDisposerTest {
     assertThat(testSubscriber.isDisposed).isFalse()
 
     rxDisposer.pause(context)
-    rxDisposer.hide(context)
+    rxDisposer.stop(context)
 
     assertThat(testSubscriber.isDisposed).isTrue()
   }

--- a/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/Expedition.kt
+++ b/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/Expedition.kt
@@ -1,7 +1,7 @@
 package com.wealthfront.magellan.sample.advanced
 
 import android.content.Context
-import com.wealthfront.magellan.LegacyExpedition
+import com.wealthfront.magellan.LegacyJourney
 import com.wealthfront.magellan.lifecycle.attachLateinitFieldToLifecycle
 import com.wealthfront.magellan.navigation.CurrentNavigableProvider
 import com.wealthfront.magellan.navigation.LoggingNavigableListener
@@ -14,7 +14,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class Expedition @Inject constructor() : LegacyExpedition<ExpeditionBinding>(
+class Expedition @Inject constructor() : LegacyJourney<ExpeditionBinding>(
   ExpeditionBinding::inflate,
   ExpeditionBinding::container
 ) {
@@ -28,7 +28,7 @@ class Expedition @Inject constructor() : LegacyExpedition<ExpeditionBinding>(
     setCurrentNavProvider(currentNavigableProvider)
   }
 
-  override fun onShow(context: Context, binding: ExpeditionBinding) {
+  override fun onStart(context: Context, binding: ExpeditionBinding) {
     ToolbarHelper.init(viewBinding!!.menu, navigator)
     navigator.showNow(DogListStep(::goToDetailsScreen))
   }

--- a/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/tide/DogBreedsStep.kt
+++ b/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/tide/DogBreedsStep.kt
@@ -27,7 +27,7 @@ class DogBreedsStep : Step<DogBreedBinding>(DogBreedBinding::inflate) {
     app(context).injector().inject(this)
   }
 
-  override fun onShow(context: Context, binding: DogBreedBinding) {
+  override fun onStart(context: Context, binding: DogBreedBinding) {
     scope.launch {
       // show loading
       val breeds = runCatching { api.getListOfAllBreedsOfRetriever() }

--- a/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/tide/DogListStep.kt
+++ b/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/tide/DogListStep.kt
@@ -13,7 +13,7 @@ import java.util.Locale
 
 class DogListStep(private val goToDogDetails: (name: String) -> Unit) : Step<DashboardBinding>(DashboardBinding::inflate) {
 
-  override fun onShow(context: Context, binding: DashboardBinding) {
+  override fun onStart(context: Context, binding: DashboardBinding) {
     ToolbarHelper.setTitle(context.getText(R.string.app_name))
     binding.dogItems.adapter = DogListAdapter(context)
   }

--- a/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/toolbar/ToolbarHelper.kt
+++ b/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/toolbar/ToolbarHelper.kt
@@ -5,14 +5,12 @@ import com.wealthfront.magellan.Navigator
 import com.wealthfront.magellan.coroutines.ShownLifecycleScope
 import com.wealthfront.magellan.lifecycle.LifecycleAwareComponent
 import com.wealthfront.magellan.lifecycle.attachFieldToLifecycle
-import com.wealthfront.magellan.navigation.NavigationLifecycleEvent
-import com.wealthfront.magellan.navigation.NavigationPropagator
 import kotlinx.coroutines.launch
 
 /**
  * [ToolbarHelper] provides APIs to modify the toolbar for the activity.
  *
- * Ideally, this dependency is provider by dependency injection and configured so that the views are cleaned up when the activity
+ * Ideally, this dependency is provided by dependency injection and configured so that the views are cleaned up when the activity
  * is destroyed with the help of (subcomponents & custom scopes)[https://dagger.dev/dev-guide/subcomponents].
  */
 object ToolbarHelper : LifecycleAwareComponent() {
@@ -27,7 +25,7 @@ object ToolbarHelper : LifecycleAwareComponent() {
     }
   }
 
-  override fun onShow(context: Context) {
+  override fun onStart(context: Context) {
     shownScope.launch {
       NavigationPropagator.events
         .filterIsInstance<NavigationLifecycleEvent.NavigatedFrom>()
@@ -37,7 +35,7 @@ object ToolbarHelper : LifecycleAwareComponent() {
     }
   }
 
-  override fun onHide(context: Context) {
+  override fun onStop(context: Context) {
     toolbarView = null
   }
 

--- a/magellan-sample/src/main/java/com/wealthfront/magellan/sample/DetailStep.kt
+++ b/magellan-sample/src/main/java/com/wealthfront/magellan/sample/DetailStep.kt
@@ -20,7 +20,7 @@ class DetailStep(
     appComponent.inject(this)
   }
 
-  override fun onShow(context: Context, binding: DetailBinding) {
+  override fun onStart(context: Context, binding: DetailBinding) {
     binding.dialog.setOnClickListener {
       dialogComponent.showDialog(DialogCreator { activity -> getDialog(activity) })
     }

--- a/magellan-sample/src/main/java/com/wealthfront/magellan/sample/FirstJourney.kt
+++ b/magellan-sample/src/main/java/com/wealthfront/magellan/sample/FirstJourney.kt
@@ -17,7 +17,7 @@ class FirstJourney(
     navigator.goTo(IntroStep(::goToLearnMore))
   }
 
-  override fun onShow(context: Context, binding: FirstJourneyBinding) {
+  override fun onStart(context: Context, binding: FirstJourneyBinding) {
     binding.nextJourney.setOnClickListener {
       goToSecondJourney()
     }

--- a/magellan-sample/src/main/java/com/wealthfront/magellan/sample/IntroStep.kt
+++ b/magellan-sample/src/main/java/com/wealthfront/magellan/sample/IntroStep.kt
@@ -8,7 +8,7 @@ internal class IntroStep(
   private val goToLearnMore: () -> Unit
 ) : Step<IntroBinding>(IntroBinding::inflate) {
 
-  override fun onShow(context: Context, binding: IntroBinding) {
+  override fun onStart(context: Context, binding: IntroBinding) {
     binding.learnMore.setOnClickListener {
       goToLearnMore()
     }


### PR DESCRIPTION
IMO this is more accurate/intuitive with our Journey/Step verbiage (e.g. start a Journey vs show a Journey). Keep onShow/onHide in relevant places for 1.0 compat