### PR TITLE
Bump test libs to support Android 12

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -3,7 +3,6 @@ import Versions.butterKnifeVersion
 import Versions.coroutinesVersion
 import Versions.daggerVersion
 import Versions.espressoVersion
-import Versions.extVersion
 import Versions.glideVersion
 import Versions.jacksonVersion
 import Versions.javaInjectVersion
@@ -64,10 +63,10 @@ object Dependencies {
   const val okhttp = "com.squareup.okhttp3:logging-interceptor:$okhttpVersion"
 
   const val testCore = "androidx.test:core:$testCoreVersion"
-  const val testRunner = "com.android.support.test:runner:$testRunnerVersion"
+  const val testRunner = "androidx.test:runner:$testRunnerVersion"
   const val testRules = "com.android.support.test:rules:$testRunnerVersion"
   const val uiAutomator ="androidx.test.uiautomator:uiautomator:$uiAutomatorVersion"
-  const val extJunit = "androidx.test.ext:junit:$extVersion"
+  const val extJunit = "androidx.test.ext:junit:$junitTestExtVersion"
   const val espressoCore = "com.android.support.test.espresso:espresso-core:$espressoVersion"
 
   const val lintApi = "com.android.tools.lint:lint-api:$lintVersion"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 object Versions {
   const val compileSdkVersion = 30
-  const val minSdkVersion = 15
+  const val minSdkVersion = 18
   const val targetSdkVersion = 30
 
   const val kotlinVersion = "1.4.30"
@@ -26,15 +26,14 @@ object Versions {
   const val materialVersion = "1.1.0"
   const val coroutinesVersion = "1.4.3"
 
-  const val testCoreVersion = "1.2.0"
-  const val junitVersion = "4.13"
-  const val junitTestExtVersion = "1.1.2"
+  const val testCoreVersion = "1.4.0"
+  const val junitVersion = "4.13.2"
+  const val junitTestExtVersion = "1.1.3"
   const val truthVersion = "1.0"
   const val mockitoVersion = "2.23.4"
-  const val testRunnerVersion = "1.0.2"
+  const val testRunnerVersion = "1.4.0"
   const val uiAutomatorVersion = "2.2.0"
-  const val extVersion = "1.1.1"
-  const val espressoVersion = "3.0.2"
+  const val espressoVersion = "3.4.0"
 
   const val lintVersion = "27.0.1"
 }

--- a/magellan-sample/src/androidTest/java/com/wealthfront/magellan/uitest/DialogTest.kt
+++ b/magellan-sample/src/androidTest/java/com/wealthfront/magellan/uitest/DialogTest.kt
@@ -2,11 +2,13 @@ package com.wealthfront.magellan.uitest
 
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.rule.ActivityTestRule
 import com.wealthfront.magellan.action.orientationLandscape
-import com.wealthfront.magellan.assertions.assertShown
 import com.wealthfront.magellan.sample.MainActivity
 import com.wealthfront.magellan.sample.R
 import org.junit.Rule
@@ -22,12 +24,19 @@ class DialogTest {
     onView(withId(R.id.nextJourney)).perform(click())
 
     onView(withId(R.id.dialog)).perform(click())
-    assertShown { text("Hello") }
-    assertShown { text("Are you sure about this?") }
+
+    assertDialogContentsShown()
 
     onView(isRoot()).perform(orientationLandscape())
 
-    assertShown { text("Hello") }
-    assertShown { text("Are you sure about this?") }
+    assertDialogContentsShown()
   }
+}
+
+private fun assertDialogContentsShown() {
+  onView(withText("Hello"))
+    .check(matches(isDisplayed()))
+
+  onView(withText("Are you sure about this?"))
+    .check(matches(isDisplayed()))
 }


### PR DESCRIPTION
So that test activities have Android 12-friendly export settings. Namely avoids errors like:
```
/Users/chrismathew/dev/Ferdinand/app/src/main/AndroidManifest.xml Error:
	android:exported needs to be explicitly specified for <activity>. Apps targeting Android 12 and higher are required to specify an explicit value for `android:exported` when the corresponding component has an intent filter defined. See https://developer.android.com/guide/topics/manifest/activity-element#exported for details.
```