### PR TITLE
Prevent multiple instances of the same Navigable on the backstack

### DIFF
--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationDelegate.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationDelegate.kt
@@ -120,6 +120,13 @@ public class NavigationDelegate(
   ) {
     val oldNavigables = oldBackStack.toSet()
     val newNavigables = newBackStack.toSet()
+    if (newNavigables.size != newBackStack.size) {
+      val numExtraNavigables = newNavigables.size - newBackStack.size
+      throw IllegalStateException(
+        "Cannot have multiple of the same Navigable in the backstack. " +
+          "Have $numExtraNavigables extra Navigables in: $newNavigables"
+      )
+    }
 
     (oldNavigables - newNavigables).forEach { oldNavigable ->
       lifecycleLimiter.removeFromLifecycle(oldNavigable)

--- a/magellan-library/src/test/java/com/wealthfront/magellan/navigation/LinearNavigatorTest.kt
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/navigation/LinearNavigatorTest.kt
@@ -5,10 +5,10 @@ import android.view.Menu
 import androidx.appcompat.app.AppCompatActivity
 import com.google.common.truth.Truth.assertThat
 import com.wealthfront.magellan.Direction.FORWARD
-import com.wealthfront.magellan.test.DummyStep
 import com.wealthfront.magellan.ScreenContainer
 import com.wealthfront.magellan.core.Journey
 import com.wealthfront.magellan.core.Step
+import com.wealthfront.magellan.test.DummyStep
 import com.wealthfront.magellan.test.databinding.MagellanDummyLayoutBinding
 import com.wealthfront.magellan.transitions.DefaultTransition
 import com.wealthfront.magellan.transitions.ShowTransition
@@ -68,6 +68,12 @@ internal class LinearNavigatorTest {
     assertThat(linearNavigator.backStack.first().magellanTransition.javaClass).isEqualTo(DefaultTransition::class.java)
   }
 
+  @Test(expected = IllegalStateException::class)
+  fun goTo_existingStep() {
+    linearNavigator.goTo(step1)
+    linearNavigator.goTo(step1)
+  }
+
   @Test
   fun show() {
     linearNavigator.goTo(step1, ShowTransition())
@@ -95,6 +101,15 @@ internal class LinearNavigatorTest {
     assertThat(linearNavigator.backStack.size).isEqualTo(1)
     assertThat(linearNavigator.backStack.first().navigable).isEqualTo(step2)
     assertThat(linearNavigator.backStack.first().magellanTransition.javaClass).isEqualTo(ShowTransition::class.java)
+  }
+
+  @Test(expected = IllegalStateException::class)
+  fun navigate_duplicateStep() {
+    linearNavigator.navigate(FORWARD) { deque ->
+      deque.push(NavigationEvent(step1, DefaultTransition()))
+      deque.push(NavigationEvent(step1, DefaultTransition()))
+      deque.peek()!!
+    }
   }
 
   @Test


### PR DESCRIPTION
Having the same navigable in multiple places in the backstack caused an issue in our main app earlier. Even before this PR, we enforce that you can attach a `LifecycleAware` to a given `LifecycleOwner` at most once, but the way we detect changes in the backstack (so we can properly attach/detach navigables) means that we didn't properly enforce that for `NavigationDelegate`. Now, we will crash if you try to add a single instance to the backstack multiple times.

(This has been sitting on my laptop for a while, whoops. 😅)