### PR TITLE
Remove javadoc-generating gradle targets

### DIFF
--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -84,36 +84,9 @@ afterEvaluate { project ->
   if (project.getPlugins().hasPlugin('com.android.application') ||
       project.getPlugins().hasPlugin('com.android.library')) {
 
-    task androidJavadocs(type: Javadoc) {
-      source = android.sourceSets.main.java.source
-      classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-      excludes = ['**/*.kt']
-    }
-
-    task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
-      classifier = 'javadoc'
-      from androidJavadocs.destinationDir
-    }
-
     task androidSourcesJar(type: Jar) {
       classifier = 'sources'
       from android.sourceSets.main.java.source
-    }
-  }
-
-  if (JavaVersion.current().isJava8Compatible()) {
-    allprojects {
-      tasks.withType(Javadoc) {
-        options.addStringOption('Xdoclint:none', '-quiet')
-      }
-    }
-  }
-
-  if (JavaVersion.current().isJava9Compatible()) {
-    allprojects {
-      tasks.withType(Javadoc) {
-        options.addBooleanOption('html5', true)
-      }
     }
   }
 
@@ -121,13 +94,6 @@ afterEvaluate { project ->
     if (project.getPlugins().hasPlugin('com.android.application') ||
         project.getPlugins().hasPlugin('com.android.library')) {
       archives androidSourcesJar
-      archives androidJavadocsJar
-    }
-  }
-
-  android.libraryVariants.all { variant ->
-    tasks.androidJavadocs.doFirst {
-      classpath += files(variant.javaCompileProvider.get().classpath.files.join(File.pathSeparator))
     }
   }
 
@@ -136,7 +102,6 @@ afterEvaluate { project ->
     publication.version = VERSION_NAME
 
     publication.artifact androidSourcesJar
-    publication.artifact androidJavadocsJar
 
     configurePom(publication.pom)
   }


### PR DESCRIPTION
With an issue to add them back in #207. I think it's a Java 11 change that's causing this to happen, but javadoc compilation doesn't work in our project anymore, even for released versions of the library.

We also don't have a lot of java code in the library anymore, so this should be fine.