### PR TITLE
Remove javadoc link from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.wealthfront/magellan-library/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.wealthfront/magellan-library)
-[![Javadocs](https://www.javadoc.io/badge/com.wealthfront/magellan-library.svg)](https://www.javadoc.io/doc/com.wealthfront/magellan-library)
 
 # Magellan
 


### PR DESCRIPTION
It only had the 3 classes that were in java, so it wasn't even useful