### PR TITLE
Conditionally restore backstack to undo unwanted operations

### DIFF
--- a/magellan-legacy/src/main/java/com/wealthfront/magellan/LegacyExpedition.kt
+++ b/magellan-legacy/src/main/java/com/wealthfront/magellan/LegacyExpedition.kt
@@ -4,20 +4,20 @@ import android.view.LayoutInflater
 import androidx.viewbinding.ViewBinding
 import com.wealthfront.magellan.core.Step
 import com.wealthfront.magellan.init.Magellan
+import com.wealthfront.magellan.init.NavigationOverride
 import com.wealthfront.magellan.lifecycle.attachFieldToLifecycle
 import com.wealthfront.magellan.navigation.CurrentNavigableProvider
-import com.wealthfront.magellan.navigation.NavigationRequestHandler
 import com.wealthfront.magellan.navigation.ViewTemplateApplier
 
 public abstract class LegacyExpedition<V : ViewBinding>(
   createBinding: (LayoutInflater) -> V,
   container: V.() -> ScreenContainer,
-  navigationRequestHandler: NavigationRequestHandler? = Magellan.navigationRequestHandler,
+  navigationOverrides: Set<NavigationOverride> = Magellan.navigationOverrides,
   templateApplier: ViewTemplateApplier? = null
 ) : Step<V>(createBinding) {
 
   public open var navigator: Navigator by attachFieldToLifecycle(
-    Navigator({ viewBinding!!.container() }, navigationRequestHandler, templateApplier)
+    Navigator({ viewBinding!!.container() }, navigationOverrides, templateApplier)
   )
 
   public fun setCurrentNavProvider(currentNavigableProvider: CurrentNavigableProvider) {

--- a/magellan-legacy/src/main/java/com/wealthfront/magellan/LegacyExpedition.kt
+++ b/magellan-legacy/src/main/java/com/wealthfront/magellan/LegacyExpedition.kt
@@ -4,15 +4,15 @@ import android.view.LayoutInflater
 import androidx.viewbinding.ViewBinding
 import com.wealthfront.magellan.core.Step
 import com.wealthfront.magellan.init.Magellan
-import com.wealthfront.magellan.init.NavigationOverride
 import com.wealthfront.magellan.lifecycle.attachFieldToLifecycle
 import com.wealthfront.magellan.navigation.CurrentNavigableProvider
+import com.wealthfront.magellan.navigation.NavigationOverrideProvider
 import com.wealthfront.magellan.navigation.ViewTemplateApplier
 
 public abstract class LegacyExpedition<V : ViewBinding>(
   createBinding: (LayoutInflater) -> V,
   container: V.() -> ScreenContainer,
-  navigationOverrides: List<NavigationOverride> = Magellan.getNavigationOverrides(),
+  navigationOverrides: NavigationOverrideProvider? = Magellan.getNavigationOverrideProvider(),
   templateApplier: ViewTemplateApplier? = null
 ) : Step<V>(createBinding) {
 

--- a/magellan-legacy/src/main/java/com/wealthfront/magellan/LegacyExpedition.kt
+++ b/magellan-legacy/src/main/java/com/wealthfront/magellan/LegacyExpedition.kt
@@ -12,7 +12,7 @@ import com.wealthfront.magellan.navigation.ViewTemplateApplier
 public abstract class LegacyExpedition<V : ViewBinding>(
   createBinding: (LayoutInflater) -> V,
   container: V.() -> ScreenContainer,
-  navigationOverrides: Set<NavigationOverride> = Magellan.navigationOverrides,
+  navigationOverrides: List<NavigationOverride> = Magellan.getNavigationOverrides(),
   templateApplier: ViewTemplateApplier? = null
 ) : Step<V>(createBinding) {
 

--- a/magellan-legacy/src/main/java/com/wealthfront/magellan/Navigator.kt
+++ b/magellan-legacy/src/main/java/com/wealthfront/magellan/Navigator.kt
@@ -5,7 +5,6 @@ import com.wealthfront.magellan.Direction.BACKWARD
 import com.wealthfront.magellan.Direction.FORWARD
 import com.wealthfront.magellan.core.Navigable
 import com.wealthfront.magellan.init.Magellan
-import com.wealthfront.magellan.init.NavigationOverride
 import com.wealthfront.magellan.init.getDefaultTransition
 import com.wealthfront.magellan.lifecycle.LifecycleAwareComponent
 import com.wealthfront.magellan.lifecycle.LifecycleState
@@ -16,6 +15,7 @@ import com.wealthfront.magellan.navigation.NavigableCompat
 import com.wealthfront.magellan.navigation.NavigationDelegate
 import com.wealthfront.magellan.navigation.NavigationEvent
 import com.wealthfront.magellan.navigation.NavigationListener
+import com.wealthfront.magellan.navigation.NavigationOverrideProvider
 import com.wealthfront.magellan.navigation.NavigationPropagator
 import com.wealthfront.magellan.navigation.Navigator
 import com.wealthfront.magellan.navigation.ViewTemplateApplier
@@ -40,7 +40,7 @@ import java.util.Deque
 @OpenForMocking
 public class Navigator(
   container: () -> ScreenContainer,
-  navigationOverrides: List<NavigationOverride> = Magellan.getNavigationOverrides(),
+  navigationOverrides: NavigationOverrideProvider? = Magellan.getNavigationOverrideProvider(),
   templateApplier: ViewTemplateApplier?
 ) : Navigator, LifecycleAwareComponent() {
 

--- a/magellan-legacy/src/main/java/com/wealthfront/magellan/Navigator.kt
+++ b/magellan-legacy/src/main/java/com/wealthfront/magellan/Navigator.kt
@@ -40,7 +40,7 @@ import java.util.Deque
 @OpenForMocking
 public class Navigator(
   container: () -> ScreenContainer,
-  navigationOverrides: Set<NavigationOverride> = Magellan.navigationOverrides,
+  navigationOverrides: List<NavigationOverride> = Magellan.getNavigationOverrides(),
   templateApplier: ViewTemplateApplier?
 ) : Navigator, LifecycleAwareComponent() {
 

--- a/magellan-legacy/src/main/java/com/wealthfront/magellan/Navigator.kt
+++ b/magellan-legacy/src/main/java/com/wealthfront/magellan/Navigator.kt
@@ -4,6 +4,8 @@ import android.app.Activity
 import com.wealthfront.magellan.Direction.BACKWARD
 import com.wealthfront.magellan.Direction.FORWARD
 import com.wealthfront.magellan.core.Navigable
+import com.wealthfront.magellan.init.Magellan
+import com.wealthfront.magellan.init.NavigationOverride
 import com.wealthfront.magellan.init.getDefaultTransition
 import com.wealthfront.magellan.lifecycle.LifecycleAwareComponent
 import com.wealthfront.magellan.lifecycle.LifecycleState
@@ -15,7 +17,6 @@ import com.wealthfront.magellan.navigation.NavigationDelegate
 import com.wealthfront.magellan.navigation.NavigationEvent
 import com.wealthfront.magellan.navigation.NavigationListener
 import com.wealthfront.magellan.navigation.NavigationPropagator
-import com.wealthfront.magellan.navigation.NavigationRequestHandler
 import com.wealthfront.magellan.navigation.Navigator
 import com.wealthfront.magellan.navigation.ViewTemplateApplier
 import com.wealthfront.magellan.navigation.goBackTo
@@ -39,11 +40,11 @@ import java.util.Deque
 @OpenForMocking
 public class Navigator(
   container: () -> ScreenContainer,
-  navigationRequestHandler: NavigationRequestHandler?,
+  navigationOverrides: Set<NavigationOverride> = Magellan.navigationOverrides,
   templateApplier: ViewTemplateApplier?
 ) : Navigator, LifecycleAwareComponent() {
 
-  protected var delegate: NavigationDelegate by attachFieldToLifecycle(NavigationDelegate(container, navigationRequestHandler, templateApplier))
+  protected var delegate: NavigationDelegate by attachFieldToLifecycle(NavigationDelegate(container, navigationOverrides, templateApplier))
 
   override val backStack: List<NavigationEvent>
     get() = delegate.backStack.toList()

--- a/magellan-library/src/main/java/com/wealthfront/magellan/core/Journey.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/core/Journey.kt
@@ -6,21 +6,21 @@ import androidx.annotation.VisibleForTesting.PROTECTED
 import androidx.viewbinding.ViewBinding
 import com.wealthfront.magellan.ScreenContainer
 import com.wealthfront.magellan.init.Magellan
+import com.wealthfront.magellan.init.NavigationOverride
 import com.wealthfront.magellan.lifecycle.attachFieldToLifecycle
 import com.wealthfront.magellan.navigation.DefaultLinearNavigator
 import com.wealthfront.magellan.navigation.LinearNavigator
-import com.wealthfront.magellan.navigation.NavigationRequestHandler
 import com.wealthfront.magellan.navigation.ViewTemplateApplier
 
 public abstract class Journey<V : ViewBinding>(
   inflateBinding: (LayoutInflater) -> V,
   protected val getContainer: V.() -> ScreenContainer,
-  navigationRequestHandler: NavigationRequestHandler? = Magellan.navigationRequestHandler,
+  navigationOverrides: Set<NavigationOverride> = Magellan.navigationOverrides,
   templateApplier: ViewTemplateApplier? = null
 ) : Step<V>(inflateBinding) {
 
   @VisibleForTesting(otherwise = PROTECTED)
   public open var navigator: LinearNavigator by attachFieldToLifecycle(
-    DefaultLinearNavigator({ viewBinding!!.getContainer() }, navigationRequestHandler, templateApplier)
+    DefaultLinearNavigator({ viewBinding!!.getContainer() }, navigationOverrides, templateApplier)
   )
 }

--- a/magellan-library/src/main/java/com/wealthfront/magellan/core/Journey.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/core/Journey.kt
@@ -6,21 +6,21 @@ import androidx.annotation.VisibleForTesting.PROTECTED
 import androidx.viewbinding.ViewBinding
 import com.wealthfront.magellan.ScreenContainer
 import com.wealthfront.magellan.init.Magellan
-import com.wealthfront.magellan.init.NavigationOverride
 import com.wealthfront.magellan.lifecycle.attachFieldToLifecycle
 import com.wealthfront.magellan.navigation.DefaultLinearNavigator
 import com.wealthfront.magellan.navigation.LinearNavigator
+import com.wealthfront.magellan.navigation.NavigationOverrideProvider
 import com.wealthfront.magellan.navigation.ViewTemplateApplier
 
 public abstract class Journey<V : ViewBinding>(
   inflateBinding: (LayoutInflater) -> V,
   protected val getContainer: V.() -> ScreenContainer,
-  navigationOverrides: List<NavigationOverride> = Magellan.getNavigationOverrides(),
+  navigationOverrideProvider: NavigationOverrideProvider? = Magellan.getNavigationOverrideProvider(),
   templateApplier: ViewTemplateApplier? = null
 ) : Step<V>(inflateBinding) {
 
   @VisibleForTesting(otherwise = PROTECTED)
   public open var navigator: LinearNavigator by attachFieldToLifecycle(
-    DefaultLinearNavigator({ viewBinding!!.getContainer() }, navigationOverrides, templateApplier)
+    DefaultLinearNavigator({ viewBinding!!.getContainer() }, navigationOverrideProvider, templateApplier)
   )
 }

--- a/magellan-library/src/main/java/com/wealthfront/magellan/core/Journey.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/core/Journey.kt
@@ -15,7 +15,7 @@ import com.wealthfront.magellan.navigation.ViewTemplateApplier
 public abstract class Journey<V : ViewBinding>(
   inflateBinding: (LayoutInflater) -> V,
   protected val getContainer: V.() -> ScreenContainer,
-  navigationOverrides: Set<NavigationOverride> = Magellan.navigationOverrides,
+  navigationOverrides: List<NavigationOverride> = Magellan.getNavigationOverrides(),
   templateApplier: ViewTemplateApplier? = null
 ) : Step<V>(inflateBinding) {
 

--- a/magellan-library/src/main/java/com/wealthfront/magellan/init/Magellan.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/init/Magellan.kt
@@ -15,7 +15,7 @@ public object Magellan {
   internal var logDebugInfo: Boolean = false
   internal var disableAnimations: Boolean = false
   internal var customDefaultTransition: MagellanTransition = DefaultTransition()
-  public var navigationOverrides: Set<NavigationOverride> = emptySet()
+  internal var navigationOverrides: List<NavigationOverride> = emptyList()
 
   @JvmStatic
   @JvmOverloads
@@ -23,7 +23,7 @@ public object Magellan {
     disableAnimations: Boolean = false,
     logDebugInfo: Boolean = false,
     defaultTransition: MagellanTransition = DefaultTransition(),
-    navigationOverrides: Set<NavigationOverride> = emptySet()
+    navigationOverrides: List<NavigationOverride> = emptyList()
   ) {
     this.logDebugInfo = logDebugInfo
     this.disableAnimations = disableAnimations
@@ -31,8 +31,12 @@ public object Magellan {
     this.navigationOverrides = navigationOverrides
   }
 
-  public fun registerNavigationOverrides(overrides: Set<NavigationOverride>) {
+  public fun setNavigationOverrides(overrides: List<NavigationOverride>) {
     this.navigationOverrides = overrides
+  }
+
+  public fun getNavigationOverrides(): List<NavigationOverride> {
+    return this.navigationOverrides
   }
 }
 

--- a/magellan-library/src/main/java/com/wealthfront/magellan/init/Magellan.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/init/Magellan.kt
@@ -5,8 +5,7 @@ import androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP_PREFIX
 import com.wealthfront.magellan.init.Magellan.customDefaultTransition
 import com.wealthfront.magellan.init.Magellan.disableAnimations
 import com.wealthfront.magellan.init.Magellan.logDebugInfo
-import com.wealthfront.magellan.navigation.NavigableCompat
-import com.wealthfront.magellan.navigation.NavigationDelegate
+import com.wealthfront.magellan.navigation.NavigationOverrideProvider
 import com.wealthfront.magellan.transitions.DefaultTransition
 import com.wealthfront.magellan.transitions.MagellanTransition
 
@@ -15,7 +14,7 @@ public object Magellan {
   internal var logDebugInfo: Boolean = false
   internal var disableAnimations: Boolean = false
   internal var customDefaultTransition: MagellanTransition = DefaultTransition()
-  internal var navigationOverrides: List<NavigationOverride> = emptyList()
+  private var navigationOverrideProvider: NavigationOverrideProvider? = null
 
   @JvmStatic
   @JvmOverloads
@@ -23,30 +22,18 @@ public object Magellan {
     disableAnimations: Boolean = false,
     logDebugInfo: Boolean = false,
     defaultTransition: MagellanTransition = DefaultTransition(),
-    navigationOverrides: List<NavigationOverride> = emptyList()
+    navigationOverrideProvider: NavigationOverrideProvider? = null
   ) {
     this.logDebugInfo = logDebugInfo
     this.disableAnimations = disableAnimations
     this.customDefaultTransition = defaultTransition
-    this.navigationOverrides = navigationOverrides
+    this.navigationOverrideProvider = navigationOverrideProvider
   }
 
-  public fun setNavigationOverrides(overrides: List<NavigationOverride>) {
-    this.navigationOverrides = overrides
-  }
-
-  public fun getNavigationOverrides(): List<NavigationOverride> {
-    return this.navigationOverrides
+  public fun getNavigationOverrideProvider(): NavigationOverrideProvider? {
+    return navigationOverrideProvider
   }
 }
-
-public data class NavigationOverride(
-  val conditions: (
-    navigationDelegate: NavigationDelegate,
-    navigable: NavigableCompat
-  ) -> Boolean,
-  val navigationOperation: (navigationDelegate: NavigationDelegate) -> Unit
-)
 
 internal fun shouldRunAnimations(): Boolean = !disableAnimations
 

--- a/magellan-library/src/main/java/com/wealthfront/magellan/init/Magellan.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/init/Magellan.kt
@@ -5,7 +5,8 @@ import androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP_PREFIX
 import com.wealthfront.magellan.init.Magellan.customDefaultTransition
 import com.wealthfront.magellan.init.Magellan.disableAnimations
 import com.wealthfront.magellan.init.Magellan.logDebugInfo
-import com.wealthfront.magellan.navigation.NavigationRequestHandler
+import com.wealthfront.magellan.navigation.NavigableCompat
+import com.wealthfront.magellan.navigation.NavigationDelegate
 import com.wealthfront.magellan.transitions.DefaultTransition
 import com.wealthfront.magellan.transitions.MagellanTransition
 
@@ -14,7 +15,7 @@ public object Magellan {
   internal var logDebugInfo: Boolean = false
   internal var disableAnimations: Boolean = false
   internal var customDefaultTransition: MagellanTransition = DefaultTransition()
-  public var navigationRequestHandler: NavigationRequestHandler? = null
+  public var navigationOverrides: Set<NavigationOverride> = emptySet()
 
   @JvmStatic
   @JvmOverloads
@@ -22,14 +23,26 @@ public object Magellan {
     disableAnimations: Boolean = false,
     logDebugInfo: Boolean = false,
     defaultTransition: MagellanTransition = DefaultTransition(),
-    navigationRequestHandler: NavigationRequestHandler? = null
+    navigationOverrides: Set<NavigationOverride> = emptySet()
   ) {
     this.logDebugInfo = logDebugInfo
     this.disableAnimations = disableAnimations
     this.customDefaultTransition = defaultTransition
-    this.navigationRequestHandler = navigationRequestHandler
+    this.navigationOverrides = navigationOverrides
+  }
+
+  public fun registerNavigationOverrides(overrides: Set<NavigationOverride>) {
+    this.navigationOverrides = overrides
   }
 }
+
+public data class NavigationOverride(
+  val conditions: (
+    navigationDelegate: NavigationDelegate,
+    navigable: NavigableCompat
+  ) -> Boolean,
+  val navigationOperation: (navigationDelegate: NavigationDelegate) -> Unit
+)
 
 internal fun shouldRunAnimations(): Boolean = !disableAnimations
 

--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/DefaultLinearNavigator.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/DefaultLinearNavigator.kt
@@ -5,7 +5,6 @@ import com.wealthfront.magellan.OpenForMocking
 import com.wealthfront.magellan.ScreenContainer
 import com.wealthfront.magellan.core.Navigable
 import com.wealthfront.magellan.init.Magellan
-import com.wealthfront.magellan.init.NavigationOverride
 import com.wealthfront.magellan.lifecycle.LifecycleAwareComponent
 import com.wealthfront.magellan.lifecycle.attachFieldToLifecycle
 import com.wealthfront.magellan.transitions.MagellanTransition
@@ -14,7 +13,7 @@ import java.util.Deque
 @OpenForMocking
 public class DefaultLinearNavigator constructor(
   container: () -> ScreenContainer,
-  navigationOverrides: List<NavigationOverride> = Magellan.getNavigationOverrides(),
+  navigationOverrides: NavigationOverrideProvider? = Magellan.getNavigationOverrideProvider(),
   templateApplier: ViewTemplateApplier? = null
 ) : LinearNavigator, LifecycleAwareComponent() {
 

--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/DefaultLinearNavigator.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/DefaultLinearNavigator.kt
@@ -4,6 +4,8 @@ import com.wealthfront.magellan.Direction
 import com.wealthfront.magellan.OpenForMocking
 import com.wealthfront.magellan.ScreenContainer
 import com.wealthfront.magellan.core.Navigable
+import com.wealthfront.magellan.init.Magellan
+import com.wealthfront.magellan.init.NavigationOverride
 import com.wealthfront.magellan.lifecycle.LifecycleAwareComponent
 import com.wealthfront.magellan.lifecycle.attachFieldToLifecycle
 import com.wealthfront.magellan.transitions.MagellanTransition
@@ -12,11 +14,11 @@ import java.util.Deque
 @OpenForMocking
 public class DefaultLinearNavigator constructor(
   container: () -> ScreenContainer,
-  navigationRequestHandler: NavigationRequestHandler?,
+  navigationOverrides: Set<NavigationOverride> = Magellan.navigationOverrides,
   templateApplier: ViewTemplateApplier? = null
 ) : LinearNavigator, LifecycleAwareComponent() {
 
-  private val delegate by attachFieldToLifecycle(NavigationDelegate(container, navigationRequestHandler, templateApplier))
+  private val delegate by attachFieldToLifecycle(NavigationDelegate(container, navigationOverrides, templateApplier))
 
   override val backStack: List<NavigationEvent>
     get() = delegate.backStack.toList()

--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/DefaultLinearNavigator.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/DefaultLinearNavigator.kt
@@ -14,7 +14,7 @@ import java.util.Deque
 @OpenForMocking
 public class DefaultLinearNavigator constructor(
   container: () -> ScreenContainer,
-  navigationOverrides: Set<NavigationOverride> = Magellan.navigationOverrides,
+  navigationOverrides: List<NavigationOverride> = Magellan.getNavigationOverrides(),
   templateApplier: ViewTemplateApplier? = null
 ) : LinearNavigator, LifecycleAwareComponent() {
 

--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationDelegate.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationDelegate.kt
@@ -23,7 +23,7 @@ import java.util.Deque
 
 public open class NavigationDelegate(
   protected val container: () -> ScreenContainer,
-  private val navigationOverrides: Set<NavigationOverride> = Magellan.navigationOverrides,
+  private val navigationOverrides: List<NavigationOverride> = Magellan.getNavigationOverrides(),
   private val templateApplier: ViewTemplateApplier?
 ) : LifecycleAwareComponent() {
 
@@ -82,7 +82,6 @@ public open class NavigationDelegate(
     containerView?.setInterceptTouchEvents(true)
     navigationPropagator.beforeNavigation()
     val oldBackStack = backStack.map { it.navigable }
-    // TODO make sure we are copying navigables by reference here
     val oldBackStackCopy = ArrayDeque(backStack)
 
     val transition = backStackOperation.invoke(backStack)

--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationDelegate.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationDelegate.kt
@@ -88,7 +88,8 @@ public open class NavigationDelegate(
     val transition = backStackOperation.invoke(backStack)
     navigationOverrides.forEach { override ->
       if (backStack.currentNavigable != null &&
-        override.conditions(this, backStack.currentNavigable!!)) {
+        override.conditions(this, backStack.currentNavigable!!)
+      ) {
         backStack.clear()
         backStack.addAll(oldBackStackCopy)
         override.navigationOperation(this)

--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationDelegate.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationDelegate.kt
@@ -82,6 +82,7 @@ public open class NavigationDelegate(
     containerView?.setInterceptTouchEvents(true)
     navigationPropagator.beforeNavigation()
     val oldBackStack = backStack.map { it.navigable }
+    // TODO make sure we are copying navigables by reference here
     val oldBackStackCopy = ArrayDeque(backStack)
 
     val transition = backStackOperation.invoke(backStack)
@@ -196,25 +197,19 @@ public open class NavigationDelegate(
   public fun atRoot(): Boolean = backStack.size <= 1
 }
 
-internal fun goToOperation(
-  nextNavigableCompat: NavigableCompat,
-  overrideMagellanTransition: MagellanTransition? = null
-): (Deque<NavigationEvent>) -> MagellanTransition = { backStack ->
-  backStack.push(
-    NavigationEvent(
-      nextNavigableCompat,
-      overrideMagellanTransition ?: getDefaultTransition()
-    )
-  )
-  backStack.peek()!!.magellanTransition
-}
-
 public fun NavigationDelegate.goTo(
   nextNavigableCompat: NavigableCompat,
   overrideMagellanTransition: MagellanTransition? = null
 ) {
-  val backstackOperation = goToOperation(nextNavigableCompat, overrideMagellanTransition)
-  navigate(FORWARD, backstackOperation)
+  navigate(FORWARD) { backStack ->
+    backStack.push(
+      NavigationEvent(
+        nextNavigableCompat,
+        overrideMagellanTransition ?: getDefaultTransition()
+      )
+    )
+    backStack.peek()!!.magellanTransition
+  }
 }
 
 public fun NavigationDelegate.replace(

--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationOverrideProvider.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationOverrideProvider.kt
@@ -1,0 +1,17 @@
+package com.wealthfront.magellan.navigation
+
+public interface NavigationOverrideProvider {
+
+  public fun getNavigationOverrides(): List<NavigationOverride>
+}
+
+public data class NavigationOverride(
+  val conditions: (
+    navigationDelegate: NavigationDelegate,
+    navigable: NavigableCompat
+  ) -> Boolean,
+  val navigationOperation: (
+    navigationDelegate: NavigationDelegate,
+    navigable: NavigableCompat
+  ) -> Unit
+)

--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/Navigator.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/Navigator.kt
@@ -2,19 +2,8 @@ package com.wealthfront.magellan.navigation
 
 import android.content.Context
 import android.view.View
-
-public interface NavigationRequestHandler {
-  public fun shouldOverrideNavigation(
-    navigationDelegate: NavigationDelegate,
-    navigable: NavigableCompat
-  ): Boolean
-
-  // what if this supplied a backstack operation, instead?
-  public fun overrideNavigationRequest(
-    navigationDelegate: NavigationDelegate,
-    navigable: NavigableCompat
-  )
-}
+import com.wealthfront.magellan.Direction
+import java.util.Deque
 
 public interface ViewTemplateApplier {
   public fun onViewCreated(context: Context, view: View): View

--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/Navigator.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/Navigator.kt
@@ -2,8 +2,6 @@ package com.wealthfront.magellan.navigation
 
 import android.content.Context
 import android.view.View
-import com.wealthfront.magellan.Direction
-import java.util.Deque
 
 public interface ViewTemplateApplier {
   public fun onViewCreated(context: Context, view: View): View

--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/Navigator.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/Navigator.kt
@@ -4,10 +4,16 @@ import android.content.Context
 import android.view.View
 
 public interface NavigationRequestHandler {
-  public fun onNavigationRequested(
+  public fun shouldOverrideNavigation(
     navigationDelegate: NavigationDelegate,
     navigable: NavigableCompat
   ): Boolean
+
+  // what if this supplied a backstack operation, instead?
+  public fun overrideNavigationRequest(
+    navigationDelegate: NavigationDelegate,
+    navigable: NavigableCompat
+  )
 }
 
 public interface ViewTemplateApplier {

--- a/magellan-library/src/test/java/com/wealthfront/magellan/navigation/DefaultLinearNavigatorTest.kt
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/navigation/DefaultLinearNavigatorTest.kt
@@ -93,10 +93,12 @@ internal class DefaultLinearNavigatorTest {
   fun show_navigationRequestHandler() {
     linearNavigator = DefaultLinearNavigator(
       { screenContainer },
-      setOf(NavigationOverride(
-        { _, navigable -> navigable == step2 },
-        { delegate -> delegate.goTo(step3) }
-      ))
+      setOf(
+        NavigationOverride(
+          { _, navigable -> navigable == step2 },
+          { delegate -> delegate.goTo(step3) }
+        )
+      )
     )
     linearNavigator.create(context)
 

--- a/magellan-library/src/test/java/com/wealthfront/magellan/navigation/DefaultLinearNavigatorTest.kt
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/navigation/DefaultLinearNavigatorTest.kt
@@ -6,7 +6,6 @@ import com.google.common.truth.Truth.assertThat
 import com.wealthfront.magellan.Direction.FORWARD
 import com.wealthfront.magellan.ScreenContainer
 import com.wealthfront.magellan.core.Journey
-import com.wealthfront.magellan.init.NavigationOverride
 import com.wealthfront.magellan.internal.test.DummyStep
 import com.wealthfront.magellan.internal.test.TransitionState.FINISHED
 import com.wealthfront.magellan.internal.test.TransitionState.NOT_STARTED
@@ -51,7 +50,7 @@ internal class DefaultLinearNavigatorTest {
     context = activityController.get()
     screenContainer = ScreenContainer(context)
 
-    linearNavigator = DefaultLinearNavigator({ screenContainer }, emptyList())
+    linearNavigator = DefaultLinearNavigator({ screenContainer })
     linearNavigator.create(context)
   }
 
@@ -93,12 +92,16 @@ internal class DefaultLinearNavigatorTest {
   fun show_navigationRequestHandler() {
     linearNavigator = DefaultLinearNavigator(
       { screenContainer },
-      listOf(
-        NavigationOverride(
-          { _, navigable -> navigable == step2 },
-          { delegate -> delegate.goTo(step3) }
-        )
-      )
+      object : NavigationOverrideProvider {
+        override fun getNavigationOverrides(): List<NavigationOverride> {
+          return listOf(
+            NavigationOverride(
+              { _, navigable -> navigable == step2 },
+              { delegate, _ -> delegate.goTo(step3) }
+            )
+          )
+        }
+      }
     )
     linearNavigator.create(context)
 

--- a/magellan-library/src/test/java/com/wealthfront/magellan/navigation/DefaultLinearNavigatorTest.kt
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/navigation/DefaultLinearNavigatorTest.kt
@@ -6,6 +6,7 @@ import com.google.common.truth.Truth.assertThat
 import com.wealthfront.magellan.Direction.FORWARD
 import com.wealthfront.magellan.ScreenContainer
 import com.wealthfront.magellan.core.Journey
+import com.wealthfront.magellan.init.NavigationOverride
 import com.wealthfront.magellan.internal.test.DummyStep
 import com.wealthfront.magellan.internal.test.TransitionState.FINISHED
 import com.wealthfront.magellan.internal.test.TransitionState.NOT_STARTED
@@ -50,15 +51,7 @@ internal class DefaultLinearNavigatorTest {
     context = activityController.get()
     screenContainer = ScreenContainer(context)
 
-    linearNavigator = DefaultLinearNavigator(
-      { screenContainer },
-      object : NavigationRequestHandler {
-        override fun onNavigationRequested(
-          navigationDelegate: NavigationDelegate,
-          navigable: NavigableCompat
-        ): Boolean = false
-      }
-    )
+    linearNavigator = DefaultLinearNavigator({ screenContainer }, emptySet())
     linearNavigator.create(context)
   }
 
@@ -100,18 +93,10 @@ internal class DefaultLinearNavigatorTest {
   fun show_navigationRequestHandler() {
     linearNavigator = DefaultLinearNavigator(
       { screenContainer },
-      object : NavigationRequestHandler {
-        override fun onNavigationRequested(
-          navigationDelegate: NavigationDelegate,
-          navigable: NavigableCompat
-        ): Boolean {
-          if (navigable == step2) {
-            navigationDelegate.goTo(step3)
-            return true
-          }
-          return false
-        }
-      }
+      setOf(NavigationOverride(
+        { _, navigable -> navigable == step2 },
+        { delegate -> delegate.goTo(step3) }
+      ))
     )
     linearNavigator.create(context)
 

--- a/magellan-library/src/test/java/com/wealthfront/magellan/navigation/DefaultLinearNavigatorTest.kt
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/navigation/DefaultLinearNavigatorTest.kt
@@ -51,7 +51,7 @@ internal class DefaultLinearNavigatorTest {
     context = activityController.get()
     screenContainer = ScreenContainer(context)
 
-    linearNavigator = DefaultLinearNavigator({ screenContainer }, emptySet())
+    linearNavigator = DefaultLinearNavigator({ screenContainer }, emptyList())
     linearNavigator.create(context)
   }
 
@@ -93,7 +93,7 @@ internal class DefaultLinearNavigatorTest {
   fun show_navigationRequestHandler() {
     linearNavigator = DefaultLinearNavigator(
       { screenContainer },
-      setOf(
+      listOf(
         NavigationOverride(
           { _, navigable -> navigable == step2 },
           { delegate -> delegate.goTo(step3) }

--- a/magellan-sample-advanced/build.gradle
+++ b/magellan-sample-advanced/build.gradle
@@ -15,6 +15,7 @@ android {
     versionName "1.0"
 
     testInstrumentationRunner "com.wealthfront.magellan.IntegrationTestRunner"
+    testInstrumentationRunnerArguments clearPackageData: 'true'
   }
 
   buildFeatures {
@@ -24,6 +25,9 @@ android {
   testOptions {
     unitTests {
       includeAndroidResources = true
+    }
+    testOptions {
+      execution 'ANDROIDX_TEST_ORCHESTRATOR'
     }
   }
 
@@ -79,4 +83,7 @@ dependencies {
   androidTestImplementation Dependencies.espressoCore
   androidTestImplementation Dependencies.testRunner
   androidTestImplementation Dependencies.testRules
+
+  androidTestImplementation 'androidx.test:runner:1.4.0'
+  androidTestUtil 'androidx.test:orchestrator:1.4.1'
 }

--- a/magellan-sample-advanced/src/androidTest/java/com/wealthfront/magellan/uitest/NavigationTest.kt
+++ b/magellan-sample-advanced/src/androidTest/java/com/wealthfront/magellan/uitest/NavigationTest.kt
@@ -94,4 +94,9 @@ class NavigationTest {
     pressBack()
     onView(withText("Welcome to the Cereal Museum!")).check(matches(isDisplayed()))
   }
+
+  @Test
+  fun suggestExhibit_nonIdempotentNavigation() {
+    // TODO
+  }
 }

--- a/magellan-sample-advanced/src/androidTest/java/com/wealthfront/magellan/uitest/NavigationTest.kt
+++ b/magellan-sample-advanced/src/androidTest/java/com/wealthfront/magellan/uitest/NavigationTest.kt
@@ -97,6 +97,10 @@ class NavigationTest {
 
   @Test
   fun suggestExhibit_nonIdempotentNavigation() {
-    // TODO
+    onView(withId(R.id.suggestExhibit)).perform(click())
+    onView(withText("Download the latest version")).check(matches(isDisplayed()))
+    pressBack()
+    onView(withId(R.id.suggestExhibit)).perform(click())
+    onView(withText("Already submitted")).check(matches(isDisplayed()))
   }
 }

--- a/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/SampleApplication.kt
+++ b/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/SampleApplication.kt
@@ -3,7 +3,8 @@ package com.wealthfront.magellan.sample.advanced
 import android.app.Application
 import android.content.Context
 import com.wealthfront.magellan.init.Magellan
-import com.wealthfront.magellan.init.NavigationOverride
+import com.wealthfront.magellan.navigation.NavigationOverride
+import com.wealthfront.magellan.navigation.NavigationOverrideProvider
 import com.wealthfront.magellan.navigation.goTo
 import com.wealthfront.magellan.sample.advanced.suggestexhibit.SuggestExhibitJourney
 import com.wealthfront.magellan.sample.advanced.update.UpdateAppStep
@@ -19,15 +20,19 @@ class SampleApplication : Application() {
       .build()
 
     Magellan.init(
-      navigationOverrides = listOf(
-        NavigationOverride(
-          { _, navigable ->
-            navigable is SuggestExhibitJourney
-          }, { navigationDelegate ->
-          navigationDelegate.goTo(UpdateAppStep())
+      navigationOverrideProvider = object : NavigationOverrideProvider {
+        override fun getNavigationOverrides(): List<NavigationOverride> {
+          return listOf(
+            NavigationOverride(
+              { _, navigable ->
+                navigable is SuggestExhibitJourney
+              }, { navigationDelegate, _ ->
+              navigationDelegate.goTo(UpdateAppStep())
+            }
+            )
+          )
         }
-        )
-      )
+      }
     )
   }
 
@@ -36,6 +41,7 @@ class SampleApplication : Application() {
   }
 
   companion object {
+
     @JvmStatic
     fun app(context: Context): SampleApplication {
       return context.applicationContext as SampleApplication

--- a/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/SampleApplication.kt
+++ b/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/SampleApplication.kt
@@ -18,15 +18,17 @@ class SampleApplication : Application() {
       .appModule(AppModule())
       .build()
 
-    Magellan.registerNavigationOverrides(setOf(
-      NavigationOverride(
-        { _, navigable ->
-          navigable is SuggestExhibitJourney
-        }, { navigationDelegate ->
+    Magellan.registerNavigationOverrides(
+      setOf(
+        NavigationOverride(
+          { _, navigable ->
+            navigable is SuggestExhibitJourney
+          }, { navigationDelegate ->
           navigationDelegate.goTo(UpdateAppStep())
         }
+        )
       )
-    ))
+    )
   }
 
   fun injector(): AppComponent {

--- a/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/SampleApplication.kt
+++ b/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/SampleApplication.kt
@@ -3,9 +3,7 @@ package com.wealthfront.magellan.sample.advanced
 import android.app.Application
 import android.content.Context
 import com.wealthfront.magellan.init.Magellan
-import com.wealthfront.magellan.navigation.NavigableCompat
-import com.wealthfront.magellan.navigation.NavigationDelegate
-import com.wealthfront.magellan.navigation.NavigationRequestHandler
+import com.wealthfront.magellan.init.NavigationOverride
 import com.wealthfront.magellan.navigation.goTo
 import com.wealthfront.magellan.sample.advanced.suggestexhibit.SuggestExhibitJourney
 import com.wealthfront.magellan.sample.advanced.update.UpdateAppStep
@@ -20,21 +18,15 @@ class SampleApplication : Application() {
       .appModule(AppModule())
       .build()
 
-    Magellan.navigationRequestHandler = object : NavigationRequestHandler {
-      override fun overrideNavigationRequest(
-        navigationDelegate: NavigationDelegate,
-        navigable: NavigableCompat
-      ) {
-        navigationDelegate.goTo(UpdateAppStep())
-      }
-
-      override fun shouldOverrideNavigation(
-        navigationDelegate: NavigationDelegate,
-        navigable: NavigableCompat
-      ): Boolean {
-        return navigable is SuggestExhibitJourney
-      }
-    }
+    Magellan.registerNavigationOverrides(setOf(
+      NavigationOverride(
+        { _, navigable ->
+          navigable is SuggestExhibitJourney
+        }, { navigationDelegate ->
+          navigationDelegate.goTo(UpdateAppStep())
+        }
+      )
+    ))
   }
 
   fun injector(): AppComponent {

--- a/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/SampleApplication.kt
+++ b/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/SampleApplication.kt
@@ -21,15 +21,18 @@ class SampleApplication : Application() {
       .build()
 
     Magellan.navigationRequestHandler = object : NavigationRequestHandler {
-      override fun onNavigationRequested(
+      override fun overrideNavigationRequest(
+        navigationDelegate: NavigationDelegate,
+        navigable: NavigableCompat
+      ) {
+        navigationDelegate.goTo(UpdateAppStep())
+      }
+
+      override fun shouldOverrideNavigation(
         navigationDelegate: NavigationDelegate,
         navigable: NavigableCompat
       ): Boolean {
-        if (navigable is SuggestExhibitJourney) {
-          navigationDelegate.goTo(UpdateAppStep())
-          return true
-        }
-        return false
+        return navigable is SuggestExhibitJourney
       }
     }
   }

--- a/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/SampleApplication.kt
+++ b/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/SampleApplication.kt
@@ -18,8 +18,8 @@ class SampleApplication : Application() {
       .appModule(AppModule())
       .build()
 
-    Magellan.registerNavigationOverrides(
-      setOf(
+    Magellan.init(
+      navigationOverrides = listOf(
         NavigationOverride(
           { _, navigable ->
             navigable is SuggestExhibitJourney

--- a/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/designcereal/DesignCerealJourney.kt
+++ b/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/designcereal/DesignCerealJourney.kt
@@ -21,7 +21,7 @@ class DesignCerealJourney(private val cerealComplete: () -> Unit) : SimpleJourne
   override var navigator: LinearNavigator by attachFieldToLifecycle(
     DefaultLinearNavigator(
       { viewBinding!!.getContainer() },
-      Magellan.getNavigationOverrides(),
+      Magellan.getNavigationOverrideProvider(),
       object : ViewTemplateApplier {
         override fun onViewCreated(context: Context, view: View): View {
           val inflater = LayoutInflater.from(context)

--- a/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/designcereal/DesignCerealJourney.kt
+++ b/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/designcereal/DesignCerealJourney.kt
@@ -21,7 +21,7 @@ class DesignCerealJourney(private val cerealComplete: () -> Unit) : SimpleJourne
   override var navigator: LinearNavigator by attachFieldToLifecycle(
     DefaultLinearNavigator(
       { viewBinding!!.getContainer() },
-      Magellan.navigationRequestHandler,
+      Magellan.navigationOverrides,
       object : ViewTemplateApplier {
         override fun onViewCreated(context: Context, view: View): View {
           val inflater = LayoutInflater.from(context)

--- a/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/designcereal/DesignCerealJourney.kt
+++ b/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/designcereal/DesignCerealJourney.kt
@@ -21,7 +21,7 @@ class DesignCerealJourney(private val cerealComplete: () -> Unit) : SimpleJourne
   override var navigator: LinearNavigator by attachFieldToLifecycle(
     DefaultLinearNavigator(
       { viewBinding!!.getContainer() },
-      Magellan.navigationOverrides,
+      Magellan.getNavigationOverrides(),
       object : ViewTemplateApplier {
         override fun onViewCreated(context: Context, view: View): View {
           val inflater = LayoutInflater.from(context)

--- a/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/suggestexhibit/SuggestConfirmationStep.kt
+++ b/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/suggestexhibit/SuggestConfirmationStep.kt
@@ -2,12 +2,14 @@ package com.wealthfront.magellan.sample.advanced.suggestexhibit
 
 import android.content.Context
 import com.wealthfront.magellan.core.Step
+import com.wealthfront.magellan.sample.advanced.R
 import com.wealthfront.magellan.sample.advanced.SampleApplication.Companion.app
 import com.wealthfront.magellan.sample.advanced.ToolbarHelper
 import com.wealthfront.magellan.sample.advanced.databinding.SuggestExhibitConfirmationBinding
 import javax.inject.Inject
 
 class SuggestConfirmationStep(
+  private val suggestionQuotaReached: Boolean = false,
   private val finishFlow: () -> Unit
 ) : Step<SuggestExhibitConfirmationBinding>(SuggestExhibitConfirmationBinding::inflate) {
 
@@ -18,7 +20,13 @@ class SuggestConfirmationStep(
   }
 
   override fun onShow(context: Context, binding: SuggestExhibitConfirmationBinding) {
-    binding.acknowledgeSubmitted.setOnClickListener { finishFlow() }
     toolbarHelper.setTitle("Thank you")
+    binding.acknowledgeSubmitted.setOnClickListener { finishFlow() }
+    val submissionMessage = if (suggestionQuotaReached) {
+      context.getString(R.string.suggest_exhibit_quota_reached)
+    } else {
+      context.getString(R.string.suggest_exhibit_success)
+    }
+    binding.submissionMessage.text = submissionMessage
   }
 }

--- a/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/suggestexhibit/SuggestExhibitJourney.kt
+++ b/magellan-sample-advanced/src/main/java/com/wealthfront/magellan/sample/advanced/suggestexhibit/SuggestExhibitJourney.kt
@@ -27,7 +27,7 @@ class SuggestExhibitJourney(private val completeSuggestion: () -> Unit) : Simple
   private fun goToConfirmation() {
     navigator.navigate(Direction.FORWARD) { backstack ->
       backstack.clear()
-      val next = NavigationEvent(SuggestConfirmationStep(completeSuggestion), DefaultTransition())
+      val next = NavigationEvent(SuggestConfirmationStep(false, completeSuggestion), DefaultTransition())
       backstack.push(next)
       next.magellanTransition
     }

--- a/magellan-sample-advanced/src/main/res/layout/suggest_exhibit_confirmation.xml
+++ b/magellan-sample-advanced/src/main/res/layout/suggest_exhibit_confirmation.xml
@@ -14,6 +14,7 @@
       >
 
     <TextView
+        android:id="@+id/submissionMessage"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/suggest_exhibit_success"

--- a/magellan-sample-advanced/src/main/res/values/strings.xml
+++ b/magellan-sample-advanced/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
   <string name="suggest_exhibit_title">Have an idea for an exhibit? Let us know!</string>
   <string name="suggest_exhibit_submit">Submit</string>
   <string name="suggest_exhibit_success">Suggestion submitted!</string>
+  <string name="suggest_exhibit_quota_reached">"Already submitted"</string>
   <string name="suggest_exhibit_success_acknowledge">Go back</string>
 
   <string name="order_tickets_adults_label">Adults:</string>


### PR DESCRIPTION
meanwhile if it's an operation we want, then just continue as normal.

The problem of the [existing "dry run" approach](https://github.com/wealthfront/magellan/pull/230/files#r789325119) is that it potentially runs all backstack operations twice - once for the "dry run", and again "for real". This causes problems if you have non-idempotent state changes inside a backstack operation (example: manipulating the intent on an Activity during deeplinking logic). 

With this approach, we're guaranteed to only run each backstack operation once.