### PR TITLE
Fix release instruction formatting

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,23 +1,23 @@
 # Releasing
 
-1a.) Change the version in gradle.properties to a non-SNAPSHOT version.
-1b.) Update the CHANGELOG.md for the impending release.
-1c.) Update the README.md with the new version.
-2.) `git commit -am "Prepare for release X.Y.Z"` (where X.Y.Z is the new version)
-3.) Open a Pull Request with the above changes. Get it merged
-4a.) Create a tag for this version: `git tag -a X.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the version)
-4b.) Push this tag to GitHub: `git push && git push --tags`
+1a. Change the version in gradle.properties to a non-SNAPSHOT version.
+1b. Update the CHANGELOG.md for the impending release.
+1c. Update the README.md with the new version.
+2. `git commit -am "Prepare for release X.Y.Z"` (where X.Y.Z is the new version)
+3. Open a Pull Request with the above changes. Get it merged
+4a. Create a tag for this version: `git tag -a X.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the version)
+4b. Push this tag to GitHub: `git push && git push --tags`
 
 Someone with the necessary permissions publishes the repo:
-5a.) `./gradlew clean publish`
-5b.) Visit [Sonatype Nexus](https://oss.sonatype.org/) and promote the artifact.
+5a. `./gradlew clean publish`
+5b. Visit [Sonatype Nexus](https://oss.sonatype.org/) and promote the artifact.
 If this step fails: drop the Sonatype repo, fix the problem, commit, and start again.
 Visit [Maven Central Repository Search](https://search.maven.org/search?q=magellan) to verify the artifact is live. Note that it may take a few hours.
 
-6.) Visit [the GitHub releases page](https://github.com/wealthfront/magellan/releases) and create a new release, copying the changelog from CHANGELOG.md.
-7a.) Change the gradle.properties to the next SNAPSHOT version.
-7b.) git commit -am "Prepare next development version"
-8.) Open a Pull Request with the above changes. Get it merged
+6. Visit [the GitHub releases page](https://github.com/wealthfront/magellan/releases) and create a new release, copying the changelog from CHANGELOG.md.
+7a. Change the gradle.properties to the next SNAPSHOT version.
+7b. git commit -am "Prepare next development version"
+8. Open a Pull Request with the above changes. Get it merged
 
 ## Publish to local maven repo
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,22 +1,25 @@
 # Releasing
 
-1a. Change the version in gradle.properties to a non-SNAPSHOT version.
-1b. Update the CHANGELOG.md for the impending release.
-1c. Update the README.md with the new version.
+1. Change the repo's metadata to reflect the impending release 
+   - Update gradle.properties to a non-SNAPSHOT version.
+   - Update CHANGELOG.md for the impending release.
+   - Update README.md with the new version.
 2. `git commit -am "Prepare for release X.Y.Z"` (where X.Y.Z is the new version)
 3. Open a Pull Request with the above changes. Get it merged
-4a. Create a tag for this version: `git tag -a X.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the version)
-4b. Push this tag to GitHub: `git push && git push --tags`
+4. Create a tag for this version
+   - `git tag -a X.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the version)
+   - Push this tag to GitHub: `git push && git push --tags`
 
-Someone with the necessary permissions publishes the repo:
-5a. `./gradlew clean publish`
-5b. Visit [Sonatype Nexus](https://oss.sonatype.org/) and promote the artifact.
+5. Someone with the necessary permissions publishes the repo:
+   - `./gradlew clean publish`
+   - Visit [Sonatype Nexus](https://oss.sonatype.org/) and promote the artifact.
 If this step fails: drop the Sonatype repo, fix the problem, commit, and start again.
 Visit [Maven Central Repository Search](https://search.maven.org/search?q=magellan) to verify the artifact is live. Note that it may take a few hours.
 
 6. Visit [the GitHub releases page](https://github.com/wealthfront/magellan/releases) and create a new release, copying the changelog from CHANGELOG.md.
-7a. Change the gradle.properties to the next SNAPSHOT version.
-7b. git commit -am "Prepare next development version"
+7. Change the repo's metadata to reflect the next development cycle 
+   - Change gradle.properties to the next SNAPSHOT version.
+   - `git commit -am "Prepare next development version"`
 8. Open a Pull Request with the above changes. Get it merged
 
 ## Publish to local maven repo


### PR DESCRIPTION
Oops: https://www.markdownguide.org/basic-syntax/#ordered-list-best-practices. 

Pro tip, use the "Rich Diff" viewer for future Markdown edits: https://github.com/wealthfront/magellan/pull/243/files?short_path=87d6a57#diff-87d6a57a759f2386bf9caf5309b9aa0b9ff0ca70f5e38696e114a1ccdb0e785d