### PR TITLE
Customizing NavigationTraverser

### DIFF
--- a/magellan-legacy/src/main/java/com/wealthfront/magellan/LegacyJourney.kt
+++ b/magellan-legacy/src/main/java/com/wealthfront/magellan/LegacyJourney.kt
@@ -5,7 +5,9 @@ import androidx.viewbinding.ViewBinding
 import com.wealthfront.magellan.core.Step
 import com.wealthfront.magellan.init.Magellan
 import com.wealthfront.magellan.lifecycle.attachFieldToLifecycle
+import com.wealthfront.magellan.navigation.BackstackNode
 import com.wealthfront.magellan.navigation.NavigableCompat
+import com.wealthfront.magellan.navigation.NavigationNode
 import com.wealthfront.magellan.navigation.NavigationOverrideProvider
 import com.wealthfront.magellan.navigation.ViewTemplateApplier
 
@@ -22,4 +24,8 @@ public abstract class LegacyJourney<V : ViewBinding>(
 
   override val currentNavigable: NavigableCompat
     get() = navigator.backStack.firstOrNull()?.navigable?.currentNavigable ?: super.currentNavigable
+
+  override fun createSnapshot(): NavigationNode {
+    return BackstackNode(this, navigator)
+  }
 }

--- a/magellan-legacy/src/main/java/com/wealthfront/magellan/Screen.java
+++ b/magellan-legacy/src/main/java/com/wealthfront/magellan/Screen.java
@@ -8,7 +8,9 @@ import android.view.ViewGroup;
 
 import com.wealthfront.magellan.coroutines.ShownLifecycleScope;
 import com.wealthfront.magellan.lifecycle.LifecycleAwareComponent;
+import com.wealthfront.magellan.navigation.LeafNode;
 import com.wealthfront.magellan.navigation.NavigableCompat;
+import com.wealthfront.magellan.navigation.NavigationNode;
 import com.wealthfront.magellan.view.DialogComponent;
 
 import org.jetbrains.annotations.NotNull;
@@ -182,6 +184,12 @@ public abstract class Screen<V extends ViewGroup & ScreenView> extends Lifecycle
   @Override
   public NavigableCompat getCurrentNavigable() {
     return this;
+  }
+
+  @NonNull
+  @Override
+  public NavigationNode createSnapshot() {
+    return new LeafNode(this);
   }
 
   /**

--- a/magellan-legacy/src/main/java/com/wealthfront/magellan/ScreenGroup.java
+++ b/magellan-legacy/src/main/java/com/wealthfront/magellan/ScreenGroup.java
@@ -4,7 +4,9 @@ import android.content.Context;
 import android.view.ViewGroup;
 
 import com.wealthfront.magellan.lifecycle.LifecycleAware;
+import com.wealthfront.magellan.navigation.LeafNode;
 import com.wealthfront.magellan.navigation.NavigableCompat;
+import com.wealthfront.magellan.navigation.NavigationNode;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -47,6 +49,12 @@ public abstract class ScreenGroup<S extends Screen, V extends ViewGroup & Screen
   @Override
   public NavigableCompat getCurrentNavigable() {
     return this;
+  }
+
+  @NonNull
+  @Override
+  public NavigationNode createSnapshot() {
+    return new LeafNode(this);
   }
 
   private void attachToLifecycleWithNavigator(@NotNull S screen) {

--- a/magellan-library/src/main/java/com/wealthfront/magellan/core/Journey.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/core/Journey.kt
@@ -7,9 +7,11 @@ import androidx.viewbinding.ViewBinding
 import com.wealthfront.magellan.ScreenContainer
 import com.wealthfront.magellan.init.Magellan
 import com.wealthfront.magellan.lifecycle.attachFieldToLifecycle
+import com.wealthfront.magellan.navigation.BackstackNode
 import com.wealthfront.magellan.navigation.DefaultLinearNavigator
 import com.wealthfront.magellan.navigation.LinearNavigator
 import com.wealthfront.magellan.navigation.NavigableCompat
+import com.wealthfront.magellan.navigation.NavigationNode
 import com.wealthfront.magellan.navigation.NavigationOverrideProvider
 import com.wealthfront.magellan.navigation.ViewTemplateApplier
 
@@ -27,4 +29,8 @@ public abstract class Journey<V : ViewBinding>(
 
   override val currentNavigable: NavigableCompat
     get() = navigator.backStack.firstOrNull()?.navigable?.currentNavigable ?: super.currentNavigable
+
+  override fun createSnapshot(): NavigationNode {
+    return BackstackNode(this, navigator)
+  }
 }

--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigableCompat.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigableCompat.kt
@@ -5,4 +5,5 @@ import com.wealthfront.magellan.lifecycle.LifecycleAware
 
 public interface NavigableCompat : LifecycleAware, Displayable {
   public val currentNavigable: NavigableCompat get() = this
+  public fun createSnapshot(): NavigationNode = LeafNode(this)
 }


### PR DESCRIPTION
Allow application developers to customize navigation traverser behavior by overriding createSnapshot. This is useful for more advanced navigation use-cases like master-detail or tabbed navigables.