### PR TITLE
Migrate JVM option names to support Java 17

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,4 @@ SNAPSHOT_REPOSITORY_URL=https://oss.sonatype.org/content/repositories/snapshots/
 android.useAndroidX=true
 android.enableJetifier=true
 
-org.gradle.jvmargs=-Xmx8g -XX:MaxPermSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx8g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8


### PR DESCRIPTION
this option works on both Java 11 and Java 17 per my testing