### PR TITLE
Adds several navigation helper shorthand functions to LinearNavigator.

### DIFF
--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/LinearNavigatorExtensions.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/LinearNavigatorExtensions.kt
@@ -1,0 +1,84 @@
+package com.wealthfront.magellan.navigation
+
+import com.wealthfront.magellan.Direction
+import com.wealthfront.magellan.core.Navigable
+import com.wealthfront.magellan.init.getDefaultTransition
+import com.wealthfront.magellan.transitions.MagellanTransition
+import com.wealthfront.magellan.transitions.NoAnimationTransition
+import java.util.Deque
+
+public fun LinearNavigator.goBackTo(navigable: Navigable) {
+  navigate(Direction.BACKWARD) { backStack ->
+    checkContains(backStack, navigable)
+    while (backStack.size > 1) {
+      if (backStack.peek()!!.navigable == navigable) {
+        break
+      }
+      backStack.pop()
+    }
+    backStack.peek()!!.magellanTransition
+  }
+}
+
+public fun LinearNavigator.goBackBefore(navigable: Navigable) {
+  navigate(Direction.BACKWARD) { backStack ->
+    checkContains(backStack, navigable)
+    while (backStack.size > 0) {
+      if (backStack.pop()!!.navigable == navigable) {
+        break
+      }
+    }
+    val peek = backStack.peek()
+      ?: throw IllegalStateException("No Navigable before ${navigable::class.java.simpleName}")
+    peek.magellanTransition
+  }
+}
+
+public fun LinearNavigator.goBackToRoot() {
+  goToRoot(Direction.BACKWARD)
+}
+
+public fun LinearNavigator.goForwardToRoot() {
+  goToRoot(Direction.FORWARD)
+}
+
+public fun LinearNavigator.resetWithRoot(root: Navigable) {
+  navigate(Direction.FORWARD) { backStack ->
+    backStack.clear()
+    val transition = NoAnimationTransition()
+    backStack.push(NavigationEvent(root, transition))
+    transition
+  }
+}
+
+public fun LinearNavigator.clearUntilRootAndGoTo(
+  navigable: Navigable,
+  overrideTransition: MagellanTransition? = null
+) {
+  navigate(Direction.FORWARD) { backStack ->
+    while (backStack.size > 1) {
+      backStack.pop()
+    }
+    val transition = overrideTransition ?: getDefaultTransition()
+    backStack.push(NavigationEvent(navigable, transition))
+    transition
+  }
+}
+
+private fun LinearNavigator.goToRoot(direction: Direction) {
+  navigate(direction) { backStack ->
+    if (backStack.isEmpty()) {
+      throw IllegalStateException("Root not found in backStack")
+    }
+    while (backStack.size > 1) {
+      backStack.pop()
+    }
+    backStack.peek()!!.magellanTransition
+  }
+}
+
+private fun checkContains(backStack: Deque<NavigationEvent>, navigable: Navigable) {
+  if (!backStack.any { it.navigable == navigable }) {
+    throw IllegalStateException("Navigable ${navigable::class.java.simpleName} not found in backStack")
+  }
+}

--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/LinearNavigatorExtensions.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/LinearNavigatorExtensions.kt
@@ -56,6 +56,9 @@ public fun LinearNavigator.clearUntilRootAndGoTo(
   overrideTransition: MagellanTransition? = null
 ) {
   navigate(Direction.FORWARD) { backStack ->
+    if (backStack.isEmpty()) {
+      throw IllegalStateException("Root not found in backStack")
+    }
     while (backStack.size > 1) {
       backStack.pop()
     }

--- a/magellan-library/src/test/java/com/wealthfront/magellan/navigation/LinearNavigatorExtensionsTest.kt
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/navigation/LinearNavigatorExtensionsTest.kt
@@ -1,0 +1,166 @@
+package com.wealthfront.magellan.navigation
+
+import androidx.appcompat.app.AppCompatActivity
+import com.google.common.truth.Truth.assertThat
+import com.wealthfront.magellan.ScreenContainer
+import com.wealthfront.magellan.internal.test.DummyStep
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class LinearNavigatorExtensionsTest {
+
+  val navigable1 = DummyStep()
+  val navigable2 = DummyStep()
+  val navigable3 = DummyStep()
+
+  lateinit var screenContainer: ScreenContainer
+  lateinit var navigator: LinearNavigator
+
+  @Before
+  fun setUp() {
+    val context = Robolectric.buildActivity(AppCompatActivity::class.java).get()
+    screenContainer = ScreenContainer(context)
+    navigator = DefaultLinearNavigator({ screenContainer })
+  }
+
+  @Test
+  fun goBackTo_navigableInBackStack() {
+    navigator.goTo(navigable1)
+    navigator.goTo(navigable2)
+    navigator.goTo(navigable3)
+    navigator.goBackTo(navigable2)
+    assertThat(navigator.backStack.first().navigable).isEqualTo(navigable2)
+  }
+
+  @Test
+  fun goBackTo_navigableNotFound() {
+    var throwable: Throwable? = null
+    try {
+      navigator.goTo(navigable1)
+      navigator.goTo(navigable3)
+      navigator.goBackTo(navigable2)
+    } catch (t: Throwable) {
+      throwable = t
+    }
+
+    assertThat(throwable).isNotNull()
+    assertThat(throwable).isInstanceOf(IllegalStateException::class.java)
+    assertThat((throwable as IllegalStateException).message)
+      .isEqualTo("Navigable DummyStep not found in backStack")
+  }
+
+  @Test
+  fun goBackTo_empty() {
+    var throwable: Throwable? = null
+    try {
+      navigator.goBackTo(navigable2)
+    } catch (t: Throwable) {
+      throwable = t
+    }
+
+    assertThat(throwable).isNotNull()
+    assertThat(throwable).isInstanceOf(IllegalStateException::class.java)
+    assertThat((throwable as IllegalStateException).message)
+      .isEqualTo("Navigable DummyStep not found in backStack")
+  }
+
+  @Test
+  fun goBackBefore_navigableInBackStack() {
+    navigator.goTo(navigable1)
+    navigator.goTo(navigable2)
+    navigator.goTo(navigable3)
+    navigator.goBackBefore(navigable2)
+    assertThat(navigator.backStack.first().navigable).isEqualTo(navigable1)
+  }
+
+  @Test
+  fun goBackBefore_nothingBeforeNavigable() {
+    var throwable: Throwable? = null
+    try {
+      navigator.goTo(navigable1)
+      navigator.goTo(navigable2)
+      navigator.goTo(navigable3)
+      navigator.goBackBefore(navigable1)
+    } catch (t: Throwable) {
+      throwable = t
+    }
+    assertThat(navigator.backStack).isEmpty()
+    assertThat((throwable as IllegalStateException).message)
+      .isEqualTo("No Navigable before DummyStep")
+  }
+
+  @Test
+  fun goBackBefore_navigableNotFound() {
+    var throwable: Throwable? = null
+    try {
+      navigator.goTo(navigable1)
+      navigator.goTo(navigable3)
+      navigator.goBackBefore(navigable2)
+    } catch (t: Throwable) {
+      throwable = t
+    }
+    assertThat(navigator.backStack).hasSize(2)
+    assertThat(throwable).isNotNull()
+    assertThat((throwable as IllegalStateException).message)
+      .isEqualTo("Navigable DummyStep not found in backStack")
+  }
+
+  @Test
+  fun goBackBefore_empty() {
+    var throwable: Throwable? = null
+    try {
+      navigator.goBackBefore(navigable2)
+    } catch (t: Throwable) {
+      throwable = t
+    }
+    assertThat(navigator.backStack).isEmpty()
+    assertThat(throwable).isNotNull()
+    assertThat((throwable as IllegalStateException).message)
+      .isEqualTo("Navigable DummyStep not found in backStack")
+  }
+
+  @Test
+  fun resetWithRoot() {
+    navigator.goTo(navigable1)
+    navigator.goTo(navigable3)
+    navigator.resetWithRoot(navigable2)
+    assertThat(navigator.backStack).hasSize(1)
+    assertThat(navigator.backStack.first().navigable).isEqualTo(navigable2)
+  }
+
+  @Test
+  fun goBackToRoot() {
+    navigator.goTo(navigable1)
+    navigator.goTo(navigable2)
+    navigator.goTo(navigable3)
+    navigator.goBackToRoot()
+    assertThat(navigator.backStack).hasSize(1)
+    assertThat(navigator.backStack.first().navigable).isEqualTo(navigable1)
+  }
+
+  @Test
+  fun goForwardToRoot() {
+    navigator.goTo(navigable1)
+    navigator.goTo(navigable2)
+    navigator.goTo(navigable3)
+    navigator.goForwardToRoot()
+    assertThat(navigator.backStack).hasSize(1)
+    assertThat(navigator.backStack.first().navigable).isEqualTo(navigable1)
+  }
+
+  @Test
+  fun clearUntilRootAndGoTo() {
+    val navigable4 = DummyStep()
+    navigator.goTo(navigable1)
+    navigator.goTo(navigable2)
+    navigator.goTo(navigable3)
+    navigator.clearUntilRootAndGoTo(navigable4)
+    assertThat(navigator.backStack).hasSize(2)
+    assertThat(navigator.backStack[0].navigable).isEqualTo(navigable4)
+    assertThat(navigator.backStack[1].navigable).isEqualTo(navigable1)
+  }
+}

--- a/magellan-library/src/test/java/com/wealthfront/magellan/navigation/LinearNavigatorExtensionsTest.kt
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/navigation/LinearNavigatorExtensionsTest.kt
@@ -143,6 +143,20 @@ class LinearNavigatorExtensionsTest {
   }
 
   @Test
+  fun goBackToRoot_empty() {
+    var throwable: Throwable? = null
+    try {
+      navigator.goBackToRoot()
+    } catch (t: Throwable) {
+      throwable = t
+    }
+    assertThat(navigator.backStack).isEmpty()
+    assertThat(throwable).isNotNull()
+    assertThat((throwable as IllegalStateException).message)
+      .isEqualTo("Root not found in backStack")
+  }
+
+  @Test
   fun goForwardToRoot() {
     navigator.goTo(navigable1)
     navigator.goTo(navigable2)
@@ -150,6 +164,20 @@ class LinearNavigatorExtensionsTest {
     navigator.goForwardToRoot()
     assertThat(navigator.backStack).hasSize(1)
     assertThat(navigator.backStack.first().navigable).isEqualTo(navigable1)
+  }
+
+  @Test
+  fun goForwardToRoot_empty() {
+    var throwable: Throwable? = null
+    try {
+      navigator.goForwardToRoot()
+    } catch (t: Throwable) {
+      throwable = t
+    }
+    assertThat(navigator.backStack).isEmpty()
+    assertThat(throwable).isNotNull()
+    assertThat((throwable as IllegalStateException).message)
+      .isEqualTo("Root not found in backStack")
   }
 
   @Test
@@ -162,5 +190,21 @@ class LinearNavigatorExtensionsTest {
     assertThat(navigator.backStack).hasSize(2)
     assertThat(navigator.backStack[0].navigable).isEqualTo(navigable4)
     assertThat(navigator.backStack[1].navigable).isEqualTo(navigable1)
+  }
+
+  @Test
+  fun clearUntilRootAndGoTo_empty() {
+    val navigable4 = DummyStep()
+    var throwable: Throwable? = null
+    try {
+      navigator.clearUntilRootAndGoTo(navigable4)
+    } catch (t: Throwable) {
+      throwable = t
+    }
+
+    assertThat(navigator.backStack).isEmpty()
+    assertThat(throwable).isNotNull()
+    assertThat((throwable as IllegalStateException).message)
+      .isEqualTo("Root not found in backStack")
   }
 }


### PR DESCRIPTION
API provides:
`goBackTo(navigable)`
`goBackBefore(navigable)`
`goBackToRoot()`
`goForwardToRoot()`
`resetWithRoot(navigable)`
`clearUntilRootAndGoTo(navigable)`