### PR TITLE
Provide fallback for CircularRevealTransition

### DIFF
--- a/magellan-library/src/main/java/com/wealthfront/magellan/transitions/CircularRevealTransition.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/transitions/CircularRevealTransition.kt
@@ -67,11 +67,15 @@ private class CircularRevealTransition(@IdRes private val clickedViewId: Int) : 
   private fun getCenterClickedView(clickedViewContainer: ViewGroup): IntArray {
     val clickedView = clickedViewContainer.findViewById<View>(clickedViewId)
     val clickedViewRect = Rect()
-    clickedView.getDrawingRect(clickedViewRect)
-    clickedViewContainer.offsetDescendantRectToMyCoords(clickedView, clickedViewRect)
-    return intArrayOf(
-      clickedViewRect.exactCenterX().toInt(),
-      clickedViewRect.exactCenterY().toInt()
-    )
+    return if (clickedView != null) {
+      clickedView.getDrawingRect(clickedViewRect)
+      clickedViewContainer.offsetDescendantRectToMyCoords(clickedView, clickedViewRect)
+      intArrayOf(
+        clickedViewRect.exactCenterX().toInt(),
+        clickedViewRect.exactCenterY().toInt()
+      )
+    } else {
+      intArrayOf(clickedViewContainer.width / 2, clickedViewContainer.height / 2)
+    }
   }
 }


### PR DESCRIPTION
if view cannot be found (e.g. due to backstack modification) than play a fullscreen circular transition

to repro the issue yourself, you can check out `circular-fallback-demo` and:
1.) Click "Start next journey" (top of screen)
2.) Click "Start next journey" (last choice in list)
3.) Press back