### PR TITLE
Don't use version catalog for project level plugin mgmt

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,21 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-plugins {
-  alias(libs.plugins.kotlin.gradle).apply(false)
-  alias(libs.plugins.kotlinter.gradle).apply(false)
-  alias(libs.plugins.kotlin.allopen).apply(false)
-  alias(libs.plugins.detekt)
+buildscript {
+  repositories {
+    jcenter()
+    mavenCentral()
+    maven {url "https://plugins.gradle.org/m2/"}
+    google()
+  }
+  dependencies {
+    classpath(Plugins.kotlinGradle)
+    classpath(Plugins.kotlinterGradle)
+    classpath(Plugins.kotlinAllOpen)
+    classpath(Plugins.detekt)
+  }
 }
+
+apply plugin: 'io.gitlab.arturbosch.detekt'
 
 allprojects {
   apply from: "$rootDir/gradle/static-analysis.gradle"

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'org.jetbrains.kotlin.jvm' version '1.8.21'
+  id 'org.jetbrains.kotlin.jvm' version '1.8.22'
 }
 
 repositories {
@@ -10,6 +10,7 @@ repositories {
 
 dependencies {
   implementation 'com.android.tools.build:gradle:8.1.2'
+  implementation 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.22'
 }
 
 compileKotlin {

--- a/buildSrc/src/main/java/Plugins.kt
+++ b/buildSrc/src/main/java/Plugins.kt
@@ -1,0 +1,10 @@
+import Versions.detektVersion
+import Versions.kotlinVersion
+import Versions.kotlinterVersion
+
+object Plugins {
+  const val kotlinGradle = "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+  const val kotlinterGradle = "org.jmailen.gradle:kotlinter-gradle:$kotlinterVersion"
+  const val kotlinAllOpen = "org.jetbrains.kotlin:kotlin-allopen:$kotlinVersion"
+  const val detekt = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:$detektVersion"
+}

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -1,4 +1,8 @@
 object Versions {
+  const val kotlinVersion = "1.8.22"
+  const val kotlinterVersion = "3.9.0"
+  const val detektVersion = "1.19.0"
+
   const val compileSdkVersion = 34
   const val minSdkVersion = 21
   const val targetSdkVersion = 30

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -102,9 +102,3 @@ lintChecks = { group = "com.android.tools.lint", name = "lint-checks", version.r
 lint = { group = "com.android.tools.lint", name = "lint", version.ref = "lint" }
 lintTests = { group = "com.android.tools.lint", name = "lint-tests", version.ref = "lint" }
 testUtils = { group = "com.android.tools", name = "testutils", version.ref = "lint" }
-
-[plugins]
-kotlin-gradle = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-kotlinter-gradle = { id = "org.jmailen.kotlinter", version.ref = "kotlinter" }
-kotlin-allopen = { id = "org.jetbrains.kotlin.plugin.allopen", version.ref = "kotlin" }
-detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }


### PR DESCRIPTION
 to avoid confusing limitations and issues

rolls back some changes https://github.com/wealthfront/magellan/pull/297/files. Also, adds kotlin-gradle-plugin to buildSrc to ensure we're using the desired Kotlin version. This is especially important for the Compose toolchain