### PR TITLE
Fix NavigationTraverser indentation

### DIFF
--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationTraverser.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/NavigationTraverser.kt
@@ -41,7 +41,7 @@ public class NavigationTraverser(private val root: NavigableCompat) {
         "$VERTICAL_LINE$INDENT_SPACE"
       }
       node.getNavigationSnapshotRecursive(
-        indent + childIndent,
+        childIndent,
         index == children.lastIndex
       )
     }.forEach { stringBuilder.append(it) }

--- a/magellan-library/src/test/java/com/wealthfront/magellan/navigation/NavigationTraverserTest.kt
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/navigation/NavigationTraverserTest.kt
@@ -84,20 +84,34 @@ internal class NavigationTraverserTest {
 
   @Test
   fun globalBackStackWithSiblingJourney() {
-    traverser = NavigationTraverser(siblingRoot)
+    val rootJourney =
+      DummyJourney(
+        DummyJourney(
+          DummyJourney(
+            DummyJourney(
+              siblingRoot
+            )
+          )
+        )
+      )
+    traverser = NavigationTraverser(rootJourney)
 
-    siblingRoot.transitionToState(Created(context))
+    rootJourney.transitionToState(Created(context))
     journey3.goToAnotherJourney()
 
     assertThat(traverser.getGlobalBackstackDescription()).isEqualTo(
       """
-    SiblingJourney
-    ├ DummyJourney3
-    | ├ DummyStep3
-    | └ DummyStep4
-    └ DummyJourney2
-      ├ DummyStep1
-      └ DummyStep2
+    DummyJourney
+    └ DummyJourney
+      └ DummyJourney
+        └ DummyJourney
+          └ SiblingJourney
+            ├ DummyJourney3
+            | ├ DummyStep3
+            | └ DummyStep4
+            └ DummyJourney2
+              ├ DummyStep1
+              └ DummyStep2
     
       """.trimIndent()
     )
@@ -126,6 +140,16 @@ internal class NavigationTraverserTest {
 
     override fun onCreate(context: Context) {
       navigator.goTo(journey1)
+    }
+  }
+
+  private inner class DummyJourney(val otherJourney: Journey<*>) : Journey<MagellanDummyLayoutBinding>(
+    MagellanDummyLayoutBinding::inflate,
+    MagellanDummyLayoutBinding::container
+  ) {
+
+    override fun onCreate(context: Context) {
+      navigator.goTo(otherJourney)
     }
   }
 


### PR DESCRIPTION
`NavigationTraverser` was exponentially increasing it's indentation the deeper the backstack. Once the backstack is deep enough, the logs become quite difficult to read. Here's an example showing the indentation issue as outputted by the test `globalBackStackWithSiblingJourney`. This PR fixes the issue highlighted by the test.
![Screenshot 2024-05-25 at 7 39 28 PM](https://github.com/wealthfront/magellan/assets/26350011/d8db50a3-2305-4d7a-93a3-cad73c8c38ce)
