### PR TITLE
Support removing navigables from LazySetNavigator

### DIFF
--- a/magellan-library/src/main/java/com/wealthfront/magellan/navigation/LazySetNavigator.kt
+++ b/magellan-library/src/main/java/com/wealthfront/magellan/navigation/LazySetNavigator.kt
@@ -1,7 +1,9 @@
 package com.wealthfront.magellan.navigation
 
 import android.content.Context
+import android.os.Build
 import android.view.View
+import androidx.annotation.RequiresApi
 import androidx.annotation.VisibleForTesting
 import com.wealthfront.magellan.Direction
 import com.wealthfront.magellan.ScreenContainer
@@ -43,15 +45,19 @@ public open class LazySetNavigator(
     lifecycleRegistry.attachToLifecycleWithMaxState(navigable, LifecycleLimit.CREATED)
   }
 
+  @RequiresApi(Build.VERSION_CODES.N)
   public fun removeNavigables(navigables: Set<NavigableCompat>) {
     for (navigable in navigables) {
       removeNavigable(navigable)
     }
   }
 
+  @RequiresApi(Build.VERSION_CODES.N)
   public fun removeNavigable(navigable: NavigableCompat) {
-    existingNavigables.remove(navigable)
-    lifecycleRegistry.removeFromLifecycle(navigable)
+    existingNavigables.removeIf { it == navigable }
+    if (lifecycleRegistry.children.contains(navigable)) {
+      lifecycleRegistry.removeFromLifecycle(navigable)
+    }
   }
 
   public fun safeAddNavigable(navigable: NavigableCompat) {
@@ -60,6 +66,7 @@ public open class LazySetNavigator(
     }
   }
 
+  @RequiresApi(Build.VERSION_CODES.N)
   public fun updateNavigables(navigables: Set<NavigableCompat>, handleCurrentTabRemoval: () -> Unit) {
     val navigablesToRemove = existingNavigables subtract navigables
     val navigablesToAdd = navigables subtract existingNavigables
@@ -87,6 +94,7 @@ public open class LazySetNavigator(
 
   override fun onDestroy(context: Context) {
     lifecycleRegistry.children.forEach { lifecycleRegistry.removeFromLifecycle(it) }
+    existingNavigables.clear()
   }
 
   public fun replace(

--- a/magellan-library/src/test/java/com/wealthfront/magellan/navigation/LazySetNavigatorTest.kt
+++ b/magellan-library/src/test/java/com/wealthfront/magellan/navigation/LazySetNavigatorTest.kt
@@ -9,6 +9,7 @@ import com.wealthfront.magellan.lifecycle.LifecycleState
 import com.wealthfront.magellan.lifecycle.transitionToState
 import com.wealthfront.magellan.transitions.CrossfadeTransition
 import io.mockk.MockKAnnotations.init
+import io.mockk.clearAllMocks
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -28,6 +29,8 @@ class LazySetNavigatorTest {
   private lateinit var navigator: LazySetNavigator
   private lateinit var step1: DummyStep
   private lateinit var step2: DummyStep
+  private lateinit var step3: DummyStep
+  private lateinit var step4: DummyStep
   @MockK private lateinit var navigableListener: NavigationListener
 
   @Before
@@ -38,6 +41,8 @@ class LazySetNavigatorTest {
     navigator = LazySetNavigator { ScreenContainer(activityController.get()) }
     step1 = DummyStep()
     step2 = DummyStep()
+    step3 = DummyStep()
+    step4 = DummyStep()
 
     NavigationPropagator.addNavigableListener(navigableListener)
   }
@@ -45,6 +50,7 @@ class LazySetNavigatorTest {
   @After
   fun tearDown() {
     NavigationPropagator.removeNavigableListener(navigableListener)
+    clearAllMocks()
   }
 
   private fun initMocks() {
@@ -100,6 +106,7 @@ class LazySetNavigatorTest {
     assertThat(navigator.containerView!!.getChildAt(0)).isEqualTo(step2.view)
     assertThat(step1.currentState).isInstanceOf(LifecycleState.Shown::class.java)
     assertThat(step2.currentState).isInstanceOf(LifecycleState.Resumed::class.java)
+    assertThat(navigator.existingNavigables).containsExactly(step1, step2)
 
     verify { navigableListener.beforeNavigation() }
     verify { navigableListener.onNavigatedFrom(step1) }
@@ -136,5 +143,123 @@ class LazySetNavigatorTest {
     assertThat(navigator.containerView!!.getChildAt(0)).isEqualTo(step1.view)
     assertThat(step1.currentState).isInstanceOf(LifecycleState.Resumed::class.java)
     assertThat(step2.currentState).isInstanceOf(LifecycleState.Shown::class.java)
+    assertThat(navigator.existingNavigables).containsExactly(step1, step2)
+  }
+
+  @Test
+  fun removeNavigables() {
+    navigator.addNavigables(setOf(step1, step2, step3, step4))
+    navigator.transitionToState(LifecycleState.Resumed(activityController.get()))
+
+    navigator.replace(step1, CrossfadeTransition())
+    step1.view!!.viewTreeObserver.dispatchOnPreDraw()
+    shadowOf(Looper.getMainLooper()).idle()
+    assertThat(navigator.containerView!!.childCount).isEqualTo(1)
+    assertThat(navigator.containerView!!.getChildAt(0)).isEqualTo(step1.view)
+    assertThat(step1.currentState).isInstanceOf(LifecycleState.Resumed::class.java)
+    assertThat(step2.currentState).isInstanceOf(LifecycleState.Created::class.java)
+    assertThat(step3.currentState).isInstanceOf(LifecycleState.Created::class.java)
+    assertThat(step4.currentState).isInstanceOf(LifecycleState.Created::class.java)
+    assertThat(navigator.existingNavigables).containsExactly(step1, step2, step3, step4)
+
+    verify { navigableListener.beforeNavigation() }
+    verify(exactly = 0) { navigableListener.onNavigatedFrom(any()) }
+    verify { navigableListener.onNavigatedTo(step1) }
+    verify { navigableListener.afterNavigation() }
+    clearMocks(navigableListener)
+    initMocks()
+
+    navigator.removeNavigables(setOf(step2, step4))
+
+    step1.view!!.viewTreeObserver.dispatchOnPreDraw()
+    shadowOf(Looper.getMainLooper()).idle()
+    assertThat(navigator.containerView!!.childCount).isEqualTo(1)
+    assertThat(navigator.containerView!!.getChildAt(0)).isEqualTo(step1.view)
+    assertThat(step1.currentState).isInstanceOf(LifecycleState.Resumed::class.java)
+    assertThat(step3.currentState).isInstanceOf(LifecycleState.Created::class.java)
+    assertThat(navigator.existingNavigables).containsExactly(step1, step3)
+
+    verify(exactly = 0) { navigableListener.onNavigatedTo(any()) }
+  }
+
+  @Test
+  fun updateMultipleNavigables() {
+    navigator.updateNavigables(setOf(step1, step2)) {}
+    navigator.transitionToState(LifecycleState.Resumed(activityController.get()))
+
+    navigator.replace(step1, CrossfadeTransition())
+    step1.view!!.viewTreeObserver.dispatchOnPreDraw()
+    shadowOf(Looper.getMainLooper()).idle()
+    assertThat(navigator.containerView!!.childCount).isEqualTo(1)
+    assertThat(navigator.containerView!!.getChildAt(0)).isEqualTo(step1.view)
+    assertThat(step1.currentState).isInstanceOf(LifecycleState.Resumed::class.java)
+    assertThat(step2.currentState).isInstanceOf(LifecycleState.Created::class.java)
+    assertThat(navigator.existingNavigables).containsExactly(step1, step2)
+
+    verify { navigableListener.beforeNavigation() }
+    verify(exactly = 0) { navigableListener.onNavigatedFrom(any()) }
+    verify { navigableListener.onNavigatedTo(step1) }
+    verify { navigableListener.afterNavigation() }
+    clearMocks(navigableListener)
+    initMocks()
+
+    navigator.updateNavigables(setOf(step1, step3, step4)) {
+      navigator.replace(step1, CrossfadeTransition())
+    }
+    navigator.replace(step3, CrossfadeTransition())
+
+    step3.view!!.viewTreeObserver.dispatchOnPreDraw()
+    shadowOf(Looper.getMainLooper()).idle()
+    assertThat(navigator.containerView!!.childCount).isEqualTo(1)
+    assertThat(navigator.containerView!!.getChildAt(0)).isEqualTo(step3.view)
+    assertThat(step1.currentState).isInstanceOf(LifecycleState.Shown::class.java)
+    assertThat(step3.currentState).isInstanceOf(LifecycleState.Resumed::class.java)
+    assertThat(step4.currentState).isInstanceOf(LifecycleState.Created::class.java)
+    assertThat(navigator.existingNavigables).containsExactly(step1, step3, step4)
+
+    verify { navigableListener.beforeNavigation() }
+    verify { navigableListener.onNavigatedFrom(step1) }
+    verify { navigableListener.onNavigatedTo(step3) }
+    verify { navigableListener.afterNavigation() }
+  }
+
+  @Test
+  fun updateMultipleNavigables_andRemoveCurrentNavigable() {
+    navigator.updateNavigables(setOf(step1, step2)) {}
+    navigator.transitionToState(LifecycleState.Resumed(activityController.get()))
+
+    navigator.replace(step2, CrossfadeTransition())
+    step2.view!!.viewTreeObserver.dispatchOnPreDraw()
+    shadowOf(Looper.getMainLooper()).idle()
+    assertThat(navigator.containerView!!.childCount).isEqualTo(1)
+    assertThat(navigator.containerView!!.getChildAt(0)).isEqualTo(step2.view)
+    assertThat(step1.currentState).isInstanceOf(LifecycleState.Created::class.java)
+    assertThat(step2.currentState).isInstanceOf(LifecycleState.Resumed::class.java)
+    assertThat(navigator.existingNavigables).containsExactly(step1, step2)
+
+    verify { navigableListener.beforeNavigation() }
+    verify(exactly = 0) { navigableListener.onNavigatedFrom(any()) }
+    verify { navigableListener.onNavigatedTo(step2) }
+    verify { navigableListener.afterNavigation() }
+    clearMocks(navigableListener)
+    initMocks()
+
+    navigator.updateNavigables(setOf(step1, step3, step4)) {
+      navigator.replace(step1, CrossfadeTransition())
+    }
+
+    step1.view!!.viewTreeObserver.dispatchOnPreDraw()
+    shadowOf(Looper.getMainLooper()).idle()
+    assertThat(navigator.containerView!!.childCount).isEqualTo(1)
+    assertThat(navigator.containerView!!.getChildAt(0)).isEqualTo(step1.view)
+    assertThat(step1.currentState).isInstanceOf(LifecycleState.Resumed::class.java)
+    assertThat(step3.currentState).isInstanceOf(LifecycleState.Created::class.java)
+    assertThat(step4.currentState).isInstanceOf(LifecycleState.Created::class.java)
+    assertThat(navigator.existingNavigables).containsExactly(step1, step3, step4)
+
+    verify { navigableListener.beforeNavigation() }
+    verify { navigableListener.onNavigatedFrom(step2) }
+    verify { navigableListener.onNavigatedTo(step1) }
+    verify { navigableListener.afterNavigation() }
   }
 }


### PR DESCRIPTION
Adding support for `LazySetNavigator` to remove navigables
- Can remove a single Navigable
- Can remove multiple Navigables
- Can update the navigator's Navigables which can add and remove Navigables